### PR TITLE
Gemma3support

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ python -c "import torch; print('MPS available:', torch.backends.mps.is_available
 ### 🚀 **Coming Soon**
 - **Additional Qwen 2.5 variants** (14B, 32B)
 - **Mistral family** support
-- **Gemma models**
+- **Gemma models** support (work in progress🔥)
 - **Enhanced quantization** (GPTQ, SpinQuant integration)
 - **Larger context lengths** (4K, 8K optimization)
 

--- a/Roadmap.MD
+++ b/Roadmap.MD
@@ -12,8 +12,7 @@
 ## In Progress Milestones 🚧
 - [ ] Re-add monolithic model support ( export_coreml)
 - [ ] SpinQuant and other Quantizatio workflows Implementation
-
-
+- [ ] Gemma Architecture Support
 ## Upcoming Milestones 🚧
 - [ ] Add Int4 Linear Quantization
 - [ ] Gemma Architecture Support

--- a/anemll-swift-cli/Sources/AnemllCore/InferenceManager.swift
+++ b/anemll-swift-cli/Sources/AnemllCore/InferenceManager.swift
@@ -19,6 +19,9 @@ import CoreFoundation
     private var FilterLLAMA01: Bool = false
     private let splitLMHead: Int
     
+    private var kvCachePrefillInputs: [String: MLMultiArray]? //kv_cache
+    private var kvCachePrefillOutputs: [String: MLMultiArray]?
+    
     private var lmheadOutputBackings: [String: MLMultiArray]?
     private var hiddenStatesBackings_emb: [String: MLMultiArray]?  // For embed output
     private var hiddenStatesBackings_ffn: [String: MLMultiArray]?  // For FFN input/output
@@ -32,6 +35,7 @@ import CoreFoundation
         get { _busy }
         set { _busy = newValue }
     }
+    
     
     // Move struct definition to class scope, before the methods
     private struct PartialMax {
@@ -92,6 +96,8 @@ import CoreFoundation
 
         try initializePrefillBackings()
         try initializeLastChunkBacking()
+        try initializeKVCachePrefill()
+        
     }
     
     
@@ -188,6 +194,10 @@ import CoreFoundation
         lmheadOutputBackings = outputBackingsDict
     }
     
+   
+    
+   
+    
     private func initializeHiddenStatesBackings() throws {
         // Check embedding model shapes first
         if debugLevel >= 1 {
@@ -217,7 +227,7 @@ import CoreFoundation
                 print("Outputs:", ffnChunks[0].inferModel.modelDescription.outputDescriptionsByName.keys)
             }
             
-            let lastDim = shape.last?.intValue ?? 2048
+            let lastDim = shape.last?.intValue ?? 1
             self.hidden_states = lastDim
             let otherDims = shape.dropLast().reduce(1) { $0 * $1.intValue }
             
@@ -305,9 +315,40 @@ import CoreFoundation
         }
     }
     
+    private func initializeKVCachePrefill() throws {
+        // Build a kv cache input dict by inspecting all chunk prefill model descriptions
+        var inputs: [String: MLMultiArray] = [:]
+
+        for chunk in ffnChunks {
+            let descInputs = chunk.prefillModel.modelDescription.inputDescriptionsByName
+            for (name, feature) in descInputs {
+                if name.hasPrefix("kv_cache_") && name.hasSuffix("_in"), let constraint = feature.multiArrayConstraint {
+                    // create MLMultiArray with the requested shape (float16)
+                    let shape = constraint.shape
+                    // avoid duplicate creation
+                    if inputs[name] == nil {
+                        let arr = try MLMultiArray(shape: shape, dataType: .float16)
+                        // zero it
+                        for i in 0..<arr.count { arr[i] = 0 }
+                        inputs[name] = arr
+                    }
+                }
+            }
+        }
+
+        // store
+        if inputs.isEmpty {
+            kvCachePrefillInputs = nil
+        } else {
+            kvCachePrefillInputs = inputs
+        }
+        // also prepare outputs container
+        kvCachePrefillOutputs = [:]
+    }
+    
     private func initializePrefillBackings() throws {
         let hiddenSize = self.hidden_states  // Adjust based on your model's hidden size
-        let shape: [NSNumber] = [1, NSNumber(value: batchSize), NSNumber(value: hiddenSize)]
+        let shape: [NSNumber] = [1, NSNumber(value: contextLength), NSNumber(value: hiddenSize)]
         let attributes: [String: Any] = [kCVPixelBufferMetalCompatibilityKey as String: true]
         
         if debugLevel >= 1 {
@@ -322,7 +363,7 @@ import CoreFoundation
         let embedStatus = CVPixelBufferCreate(
             kCFAllocatorDefault,
             hiddenSize,  // Width
-            batchSize,   // Height
+            contextLength,   // Height
             kCVPixelFormatType_OneComponent16Half,
             attributes as CFDictionary,
             &embedPixelBuffer
@@ -341,7 +382,7 @@ import CoreFoundation
         let ffnStatus = CVPixelBufferCreate(
             kCFAllocatorDefault,
             hiddenSize,
-            batchSize,
+            contextLength,
             kCVPixelFormatType_OneComponent16Half,
             attributes as CFDictionary,
             &ffnPixelBuffer
@@ -408,7 +449,6 @@ import CoreFoundation
             }
         }
     }
-    
     public func runStPrefill(
         on contextTokens: inout [Int],
         contextPos: Int,
@@ -444,46 +484,56 @@ import CoreFoundation
             throw InferenceError.inferenceError("ffnChunks was nil in runPrefill()")
         }
         var batchPos = 0
+
+        // Ensure kvCachePrefillInputs exists (may be nil if model doesn't use unified kv inputs)
+        if kvCachePrefillInputs == nil {
+            // try to initialize if not present
+            try initializeKVCachePrefill()
+        }
+
         while batchPos < contextPos {
             let batchEnd = min(batchPos + batchSize, contextPos)
             let currentBatchSize = batchEnd - batchPos
-            
+
             if debugLevel >= 1 {
                 print("\nPrefill batch: \(batchPos) to \(batchEnd), currentBatchSize: \(currentBatchSize)")
             }
-            
-            // Create input tensor for current batch
-            let batchInput = try MLMultiArray(shape: [1, NSNumber(value: batchSize)], dataType: .int32)
+
+            // Create input tensor for current batch: we use contextLength as width, but only fill currentBatchSize
+            let batchInput = try MLMultiArray(shape: [1, NSNumber(value: contextLength)], dataType: .int32)
+            for i in 0..<contextLength {
+                // default pad with zeros (or pad token if desired)
+                batchInput[[0, i] as [NSNumber]] = 0
+            }
             for i in 0..<currentBatchSize {
                 batchInput[[0, i] as [NSNumber]] = NSNumber(value: contextTokens[batchPos + i])
             }
-            
-            // Generate position IDs
-            let positionIds = try MLMultiArray(shape: [NSNumber(value: batchSize)], dataType: .int32)
-            for i in 0..<batchSize {
+
+            // Generate position IDs (length = contextLength, but we fill from batchPos)
+            let positionIds = try MLMultiArray(shape: [1, NSNumber(value: contextLength)], dataType: .int32)
+            for i in 0..<contextLength {
                 positionIds[i] = NSNumber(value: batchPos + i)
             }
-            
-            // Create batch causal mask
+
+            // Create batch causal mask: [1,1,contextLength,contextLength]
             let batchCausalMask = try MLMultiArray(
-                shape: [1, 1, NSNumber(value: batchSize), NSNumber(value: contextLength)],  // Always use full contextLength
+                shape: [1, 1, NSNumber(value: contextLength), NSNumber(value: contextLength)],
                 dataType: .float16
             )
-            
-            // Fill with -inf by default
+            // Fill with -inf first
+            let negInf = Float(-Float.infinity)
             for i in 0..<batchCausalMask.count {
-                batchCausalMask[i] = NSNumber(value: Float(-Float.infinity))
+                batchCausalMask[i] = NSNumber(value: negInf)
             }
-            
-            // Set causal attention pattern
-            for i in 0..<batchSize {
-                for j in 0..<contextLength {  // Use full contextLength
+            // Set causal pattern
+            for i in 0..<contextLength {
+                for j in 0..<contextLength {
                     if j <= (batchPos + i) {
                         batchCausalMask[[0, 0, i, j] as [NSNumber]] = NSNumber(value: Float(0.0))
                     }
                 }
             }
-            
+
             // Run embeddings with prefill backing
             let embedInput = try MLDictionaryFeatureProvider(dictionary: ["input_ids": batchInput])
             let embedOptions = MLPredictionOptions()
@@ -494,7 +544,7 @@ import CoreFoundation
                     print("Embedding input shape:", batchInput.shape.map { $0.intValue })
                 }
             }
-            
+
             if debugLevel >= 1 {
                 print("About to run embedding model prediction...")
             }
@@ -502,76 +552,129 @@ import CoreFoundation
             if debugLevel >= 1 {
                 print("Embedding model prediction completed successfully")
             }
-            
+
             guard let hiddenStates = hiddenStatesBackings_emb_prefill?["hidden_states"] else {
                 throw InferenceError.inferenceError("Missing embed prefill output backing")
             }
-            
+
             if debugLevel >= 1 {
                 print("Retrieved hidden states from embedding with shape:", hiddenStates.shape.map { $0.intValue })
             }
-            
+
             // Process FFN chunks
-            var currentHiddenStates = hiddenStates  // Shape: [1, 128, hidden_states]
+            var currentHiddenStates = hiddenStates
             let chunkCount = ffnChunks.count
-            
+
             for (index, chunk) in ffnChunks.enumerated() {
                 let isLastChunk = index == chunkCount - 1
                 let ffnOptions = MLPredictionOptions()
-                
+
                 if debugLevel >= 1 {
                     print("\nFFN chunk \(index + 1)/\(chunkCount), isLastChunk: \(isLastChunk)")
                     print("Current hidden states shape:", currentHiddenStates.shape.map { $0.intValue })
                 }
-                
-                // Assign output backing BEFORE predict
-                // Check what shape the model expects by looking at its OUTPUT description
+
+                // Decide which hidden-state output backing to use (last chunk small shape vs full batch)
                 var useLastChunkBacking = false
-                
                 if let outputDesc = chunk.prefillModel.modelDescription.outputDescriptionsByName["output_hidden_states"],
                    let constraint = outputDesc.multiArrayConstraint {
                     let expectedBatchDim = constraint.shape[1].intValue
                     if debugLevel >= 1 {
                         print("Chunk \(index + 1) prefill model expects output shape: \(constraint.shape.map { $0.intValue })")
                     }
-                    // If model expects output batch dim of 1, use last chunk backing
                     useLastChunkBacking = (expectedBatchDim == 1)
                 }
-                
+
+                // Prepare outputBackings dictionary to include output_hidden_states AND kv outputs
+                var localOutBackings: [String: MLMultiArray] = [:]
+
                 if useLastChunkBacking && !v110 {
                     if let backings = hiddenStatesBackings_last {
-                        ffnOptions.outputBackings = backings  // Shape: [1, 1, hidden_states]
+                        // copy entries into localOutBackings
+                        for (k, v) in backings {
+                            localOutBackings[k] = v
+                        }
                         if debugLevel >= 1 {
                             print("Using last chunk backing with shape:", backings["output_hidden_states"]?.shape.map { $0.intValue } ?? [])
                         }
                     }
                 } else {
-                    // For models expecting batch shape or when v110=true
                     if let backings = hiddenStatesBackings_ffn_prefill {
-                        ffnOptions.outputBackings = backings  // Shape: [1, batch_size, hidden_states]
+                        for (k, v) in backings {
+                            localOutBackings[k] = v
+                        }
                         if debugLevel >= 1 {
                             print("Using FFN prefill backing with shape:", backings["output_hidden_states"]?.shape.map { $0.intValue } ?? [])
                         }
                     }
                 }
-                
-                let currentPosArray = try MLMultiArray(shape: [1], dataType: .int32)
-                currentPosArray[0] = NSNumber(value: batchPos)
-                
-                let prefillInput = try MLDictionaryFeatureProvider(dictionary: [
-                    "hidden_states": currentHiddenStates,  // Shape: [1, 128, hidden_states]
+
+                // Inspect chunk model outputs and create backings for kv outputs if needed
+                let outDescMap = chunk.prefillModel.modelDescription.outputDescriptionsByName
+                for (outName, feat) in outDescMap {
+                    if (outName.hasPrefix("key_cache_") || outName.hasPrefix("value_cache_")) && outName.hasSuffix("_out"),
+                       let constraint = feat.multiArrayConstraint {
+                        if localOutBackings[outName] == nil {
+                            // create fresh MLMultiArray with required shape
+                            let shape = constraint.shape
+                            let arr = try MLMultiArray(shape: shape, dataType: .float16)
+                            for i in 0..<arr.count { arr[i] = 0 }
+                            localOutBackings[outName] = arr
+                        }
+                    }
+                }
+
+                // Set output backings
+                ffnOptions.outputBackings = localOutBackings
+
+                // Build input dictionary, include KV cache inputs (from kvCachePrefillInputs) if model expects them
+                var inputDict: [String: Any] = [
+                    "hidden_states": currentHiddenStates,
                     "position_ids": positionIds,
                     "causal_mask": batchCausalMask,
-                    "current_pos": currentPosArray
-                ])
-                
-                // Run prediction with the assigned output backing
-                _ = try await chunk.prefillModel.prediction(
-                    from: prefillInput,
-                    using: state,
-                    options: ffnOptions
-                )
-                
+                    "current_pos": try {
+                        let a = try MLMultiArray(shape: [1], dataType: .int32)
+                        a[0] = NSNumber(value: batchPos)
+                        return a
+                    }()
+                ]
+
+                // For each declared input in the prefill model that matches kv_cache_*_in, attach the stored array
+                let inDescMap = chunk.prefillModel.modelDescription.inputDescriptionsByName
+                for (inName, feat) in inDescMap {
+                    if inName.hasPrefix("kv_cache_") && inName.hasSuffix("_in") {
+                        // prefer stored value in kvCachePrefillInputs, else create a zero array with declared shape
+                        if let existing = kvCachePrefillInputs?[inName] {
+                            inputDict[inName] = existing
+                        } else if let constraint = feat.multiArrayConstraint {
+                            let shape = constraint.shape
+                            let arr = try MLMultiArray(shape: shape, dataType: .float16)
+                            for i in 0..<arr.count { arr[i] = 0 }
+                            // store it so next chunk/batch can reuse
+                            if kvCachePrefillInputs == nil { kvCachePrefillInputs = [:] }
+                            kvCachePrefillInputs?[inName] = arr
+                            inputDict[inName] = arr
+                        } else {
+                            // fallback: skip if no constraint (unlikely)
+                        }
+                    }
+                }
+
+                let prefillInput = try MLDictionaryFeatureProvider(dictionary: inputDict)
+
+                // Run prediction with the assigned output backing (and state)
+                _ = try await chunk.prefillModel.prediction(from: prefillInput, using: state, options: ffnOptions)
+
+                // After prediction, collect kv outputs and store them for next iterations
+                for (outName, arr) in localOutBackings {
+                    if outName.hasPrefix("key_cache_") || outName.hasPrefix("value_cache_") {
+                        // store into kvCachePrefillOutputs for use or combine into next input
+                        kvCachePrefillOutputs?[outName] = arr
+                        // also mirror to kvCachePrefillInputs so next prefill invocation will find it
+                        kvCachePrefillInputs?[outName.replacingOccurrences(of: "_out", with: "_in")] = arr
+                    }
+                }
+
                 // Update currentHiddenStates - use the appropriate backing based on what model expects
                 if useLastChunkBacking && !v110 {
                     guard let nextHiddenStates = hiddenStatesBackings_last?["output_hidden_states"] else {
@@ -584,17 +687,19 @@ import CoreFoundation
                     }
                     currentHiddenStates = nextHiddenStates  // Shape: [1, batch_size, hidden_states]
                 }
-                
+
                 if debugLevel >= 2 {
                     debugTensor(currentHiddenStates, prefix: "FFN chunk \(index + 1) output")
                 }
             }
-            
+
             batchPos = batchEnd
         }
-        
+
         return contextPos
     }
+    
+    
 
     func topPSample(logits: [Float], temperature: Float = 1.0, topP: Float = 0.9) -> Int {
         // Apply temperature scaling
@@ -870,12 +975,12 @@ import CoreFoundation
                 print("\nTop-p sampled token:", sampledIndex)
             }
             return sampledIndex
-        }   
+        }
      }
     
     /// Shifts the context window if needed (similar to the Python code).
     public func shiftWindow(
-        currentPos: Int,  
+        currentPos: Int,
         contextTokens: inout [Int],
         onWindowShift: (() -> Void)? = nil
     ) throws {

--- a/anemll-swift-cli/Sources/AnemllCore/InferenceManager.swift
+++ b/anemll-swift-cli/Sources/AnemllCore/InferenceManager.swift
@@ -19,7 +19,7 @@ import CoreFoundation
     private var FilterLLAMA01: Bool = false
     private let splitLMHead: Int
     
-    private var kvCachePrefillInputs: [String: MLMultiArray]? //kv_cache
+    private var kvCachePrefillInputs: [String: MLMultiArray]? //For KV_Cache
     private var kvCachePrefillOutputs: [String: MLMultiArray]?
     
     private var lmheadOutputBackings: [String: MLMultiArray]?
@@ -66,7 +66,7 @@ import CoreFoundation
         self.v110 = v110 // Set the v110 flag based on the parameter
 
         
-        print("InferenceManager initialized with v110=\(v110), splitLMHead=\(splitLMHead), batchSize=\(batchSize)")
+        print("InferenceManager initialized with v110=\(v110), splitLMHead=\(splitLMHead), batchSize=\(batchSize), debugLevel=\(debugLevel)")
         self.fullCausalMask = try MLMultiArray(shape: [1, 1, NSNumber(value: contextLength), NSNumber(value: contextLength)], dataType: .float16)
 
         self.initState()
@@ -132,6 +132,8 @@ import CoreFoundation
         print("Debug level set to \(debugLevel)")
     }
     
+   
+    
     private func initializeLMHeadOutputBackings() throws {
         let outputDescription = lmheadModel.modelDescription.outputDescriptionsByName
         let featureNames = (1...splitLMHead).map { i in "logits\(i)" }
@@ -194,89 +196,59 @@ import CoreFoundation
         lmheadOutputBackings = outputBackingsDict
     }
     
-   
-    
-   
-    
     private func initializeHiddenStatesBackings() throws {
-        // Check embedding model shapes first
+        // inferModel input "hidden_states" should be [1,1,hidden]
+        guard let desc = ffnChunks.first?.inferModel.modelDescription.inputDescriptionsByName["hidden_states"],
+              let constraint = desc.multiArrayConstraint else {
+            throw InferenceError.inferenceError("Failed to read ffn inferModel hidden_states constraint")
+        }
+        let shape = constraint.shape // expect [1,1,1152]
         if debugLevel >= 1 {
-            print("\n=== Embedding Model Shapes ===")
-            for (name, desc) in embedModel.modelDescription.inputDescriptionsByName {
-                if let constraint = desc.multiArrayConstraint {
-                    print("Embed Input \(name):", constraint.shape.map { $0.intValue })
-                }
-            }
-            for (name, desc) in embedModel.modelDescription.outputDescriptionsByName {
-                if let constraint = desc.multiArrayConstraint {
-                    print("Embed Output \(name):", constraint.shape.map { $0.intValue })
-                }
-            }
+            print("FFN infer input shape from model:", shape.map { $0.intValue })
         }
-        
-        // Get shape from FFN model's input
-        if let desc = ffnChunks[0].inferModel.modelDescription.inputDescriptionsByName["hidden_states"],
-           let constraint = desc.multiArrayConstraint {
-            let shape = constraint.shape
-            
-            if debugLevel >= 1 {
-                print("\n=== FFN Model Shapes ===")
-                print("FFN Model Input Shape:", shape.map { $0.intValue })
-                print("\nFFN Model Features:")
-                print("Inputs:", ffnChunks[0].inferModel.modelDescription.inputDescriptionsByName.keys)
-                print("Outputs:", ffnChunks[0].inferModel.modelDescription.outputDescriptionsByName.keys)
-            }
-            
-            let lastDim = shape.last?.intValue ?? 1
-            self.hidden_states = lastDim
-            let otherDims = shape.dropLast().reduce(1) { $0 * $1.intValue }
-            
-            let attributes: [String: Any] = [
-                kCVPixelBufferMetalCompatibilityKey as String: true
-            ]
-            
-            // Create embed output backing
-            var embedPixelBuffer: CVPixelBuffer?
-            let embedStatus = CVPixelBufferCreate(
-                kCFAllocatorDefault,
-                lastDim,
-                otherDims,
-                kCVPixelFormatType_OneComponent16Half,
-                attributes as CFDictionary,
-                &embedPixelBuffer
-            )
-            
-            guard embedStatus == kCVReturnSuccess, let embedBuffer = embedPixelBuffer else {
-                throw InferenceError.inferenceError("Failed to create pixel buffer for embed output")
-            }
-            
-            // Store embed output backing
-            hiddenStatesBackings_emb = ["hidden_states": MLMultiArray(pixelBuffer: embedBuffer, shape: shape)]
-            
-            if debugLevel >= 1 {
-                print("Single-token embed backing shape:", shape.map { $0.intValue })
-            }
-            
-            // Create FFN output backing
-            var ffnPixelBuffer: CVPixelBuffer?
-            let ffnStatus = CVPixelBufferCreate(
-                kCFAllocatorDefault,
-                lastDim,
-                otherDims,
-                kCVPixelFormatType_OneComponent16Half,
-                attributes as CFDictionary,
-                &ffnPixelBuffer
-            )
-            
-            guard ffnStatus == kCVReturnSuccess, let ffnBuffer = ffnPixelBuffer else {
-                throw InferenceError.inferenceError("Failed to create pixel buffer for FFN output")
-            }
-            
-            // Store FFN input/output backing
-            hiddenStatesBackings_ffn = ["output_hidden_states": MLMultiArray(pixelBuffer: ffnBuffer, shape: shape)]
-        }
-    }
 
+        let hiddenSize = shape.last?.intValue ?? self.hidden_states
+        self.hidden_states = hiddenSize
+
+        // create pixel buffer for single-token decode: height = 1
+        let attributes: [String: Any] = [ kCVPixelBufferMetalCompatibilityKey as String: true ]
+        var ffnPixelBuffer: CVPixelBuffer?
+        let ffnStatus = CVPixelBufferCreate(
+            kCFAllocatorDefault,
+            hiddenSize,   // width = hidden_size
+            1,            // height = 1 for decode
+            kCVPixelFormatType_OneComponent16Half,
+            attributes as CFDictionary,
+            &ffnPixelBuffer
+        )
+        guard ffnStatus == kCVReturnSuccess, let ffnBuffer = ffnPixelBuffer else {
+            throw InferenceError.inferenceError("Failed to create single-token FFN pixel buffer")
+        }
+        hiddenStatesBackings_ffn = ["output_hidden_states": MLMultiArray(pixelBuffer: ffnBuffer, shape: shape)]
+
+        if debugLevel >= 1 {
+            print("FFN decode backing shape:", shape.map { $0.intValue })
+        }
+
+        // Also create single-token embed backing [1,1,1152] (for generateNextToken embed case)
+        var embedPixelBuffer: CVPixelBuffer?
+        let embedStatus = CVPixelBufferCreate(
+            kCFAllocatorDefault,
+            hiddenSize,
+            1,
+            kCVPixelFormatType_OneComponent16Half,
+            attributes as CFDictionary,
+            &embedPixelBuffer
+        )
+        guard embedStatus == kCVReturnSuccess, let embedBuf = embedPixelBuffer else {
+            throw InferenceError.inferenceError("Failed to create single-token embed pixel buffer")
+        }
+        hiddenStatesBackings_emb = ["hidden_states": MLMultiArray(pixelBuffer: embedBuf, shape: shape)]
+    }
+    
+   
+    
+    
 
     private func initializeLastChunkBacking() throws {
         guard let desc = ffnChunks.last?.prefillModel.modelDescription.outputDescriptionsByName["output_hidden_states"],

--- a/anemll-swift-cli/Sources/AnemllCore/Tokenizer.swift
+++ b/anemll-swift-cli/Sources/AnemllCore/Tokenizer.swift
@@ -121,7 +121,9 @@ public final class Tokenizer: @unchecked Sendable {
                         "llama": "</s>",
                         "mistral": "</s>",
                         "falcon": "</s>",
-                        "chatglm": "</s>"
+                        "chatglm": "</s>",
+                        "gemma3": "<eos>"
+                        
                     ]
                     
                     if let templateToken = eosTokenMap[template] {
@@ -153,7 +155,8 @@ public final class Tokenizer: @unchecked Sendable {
                         "llama": "<s>",
                         "mistral": "<s>",
                         "falcon": "<s>",
-                        "chatglm": "<s>"
+                        "chatglm": "<s>",
+                        "gemma3": "<bos>"
                     ]
                     
                     if let templateToken = bosTokenMap[template] {
@@ -185,7 +188,8 @@ public final class Tokenizer: @unchecked Sendable {
                         "llama": "<pad>",
                         "mistral": "<pad>",
                         "falcon": "<pad>",
-                        "chatglm": "<pad>"
+                        "chatglm": "<pad>",
+                        "gemma3": "<pad>"
                     ]
                     
                     if let templateToken = padTokenMap[template] {

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -525,8 +525,126 @@ class Gemma3Converter(BaseConverter):
             end_layer = min((chunk_idx + 1) * layers_per_chunk, total_layers)
         else:
             start_layer = 0
-            end_layer = None
+            end_layer = total_layers
 
+        print(f"Converting prefill part {chunk_idx+1}/{total_chunks} "
+              f"({start_layer}-{end_layer})")
+
+        class PrefillWrapper(torch.nn.Module):
+            def __init__(self, model: Gemma3ForCausalLM, start_layer: int, end_layer: int) -> None:
+                super().__init__()
+                self.layers = nn.ModuleList([
+                    model.model.layers[i] for i in range(start_layer, end_layer)
+                ])
+                self.rotary_emb_local = model.model.rotary_emb_local
+                self.rotary_emb_global = model.model.rotary_emb
+            
+            def forward(
+                self,
+                hidden_states: torch.Tensor,
+                position_ids: torch.Tensor,
+                causal_mask: torch.Tensor,
+                current_pos: torch.Tensor,
+            ):
+                cos_global, sin_global = self.rotary_emb_global(
+                    hidden_states, position_ids, seq_len=position_ids.shape[1]
+                )
+                cos_local, sin_local = self.rotary_emb_local(
+                    hidden_states, position_ids, seq_len=position_ids.shape[1]
+                )
+                
+                for decoder_layer in self.layers:
+                    if decoder_layer.self_attn.is_sliding:
+                        position_embeddings = (cos_local, sin_local)
+                    else:
+                        position_embeddings = (cos_global, sin_global)
+                    
+                    # Passing KV cache to the layer
+                    layer_outputs = decoder_layer(
+                        hidden_states,
+                        position_embeddings=position_embeddings,
+                        attention_mask=causal_mask,
+                        position_ids=position_ids,
+                        use_cache=True,
+                        cache_position=current_pos,
+                    )
+                    hidden_states = layer_outputs[0]
+
+                # The Prefill wrapper MUST return a tuple of (output, state)
+                return hidden_states, tuple(
+                    layer_outputs[1].split(
+                        model.model.config.hidden_size, dim=-1
+                    )
+                    for layer_outputs in hidden_states.shape[0]
+                )
+
+
+        wrapper = PrefillWrapper(model, start_layer, end_layer)
+        wrapper.eval()
+
+        sample_hidden_states = torch.zeros(
+            (1, self.context_length, model.config.hidden_size),
+            dtype=torch.float16,
+            device=TEST_DEVICE,
+        )
+        sample_position_ids = torch.zeros(
+            (1, self.context_length), dtype=torch.int32, device=TEST_DEVICE
+        )
+        sample_causal_mask = torch.zeros(
+            (1, 1, self.context_length, self.context_length),
+            dtype=torch.float16,
+            device=TEST_DEVICE,
+        )
+        sample_current_pos = torch.zeros((1,), dtype=torch.int32, device=TEST_DEVICE)
+
+        traced = torch.jit.trace(
+            wrapper,
+            (
+                sample_hidden_states,
+                sample_position_ids,
+                sample_causal_mask,
+                sample_current_pos,
+            ),
+        )
+
+        mlmodel = ct.convert(
+            traced,
+            inputs=[
+                ct.TensorType(
+                    name="hidden_states", shape=sample_hidden_states.shape, dtype=np.float16
+                ),
+                ct.TensorType(
+                    name="position_ids", shape=sample_position_ids.shape, dtype=np.int32
+                ),
+                ct.TensorType(
+                    name="causal_mask", shape=sample_causal_mask.shape, dtype=np.float16
+                ),
+                ct.TensorType(
+                    name="current_pos", shape=sample_current_pos.shape, dtype=np.int32
+                ),
+            ],
+            outputs=[
+                ct.TensorType(name="output_hidden_states", dtype=np.float16),
+                ct.TensorType(
+                    name="kv_cache_output",
+                    shape=(
+                        2 * model.config.num_hidden_layers,
+                        self.context_length,
+                        model.config.num_key_value_heads,
+                        model.config.head_dim
+                    ),
+                    dtype=np.float16,
+                ),
+            ],
+            states=self.GetTransformerStates(model, part="2_prefill", prefix="model.model."),
+            compute_precision=ct.precision.FLOAT16,
+            compute_units=ct.ComputeUnit.CPU_AND_NE,
+            minimum_deployment_target=ct.target.iOS18,
+            convert_to="mlprogram",
+        )
+        
+        return mlmodel
+    
 class PrefillWrapper(torch.nn.Module):
 
     def __init__(self, model: Gemma3ForCausalLM, start_layer=0, end_layer=None):

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -677,6 +677,10 @@ class Gemma3Converter(BaseConverter):
             minimum_deployment_target=ct.target.iOS18,
             convert_to="mlprogram",
         )
+        if self.lut_bits:
+            self.converted_model = mlmodel
+            self.postprocess(num_workers=8)  # Allow passing num_workers if needed
+            mlmodel = self.converted_model
         
         return mlmodel
     

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -837,7 +837,7 @@ class Gemma3Converter(BaseConverter):
         wrapper.eval()
 
         # Create sample input for tracing
-        sample_input = torch.zeros((1, 1), dtype=torch.int32, device=TEST_DEVICE)
+        sample_input = torch.zeros((1, 512), dtype=torch.int32, device=TEST_DEVICE)
 
         # Trace model
         print("Tracing embeddings model...")

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -1,0 +1,1038 @@
+"""Converter for Gemma 3 models.
+
+This module provides a lightweight converter that mirrors the
+:class:`QwenConverter` behaviour for Gemma3 models without inheriting from
+it. Only the pieces required for the unit tests are implemented."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Optional, List
+
+import numpy as np
+import torch
+import coremltools as ct
+import coremltools.optimize as cto
+
+from .environment import require_coreml
+
+from .base_converter import BaseConverter
+from .metadata import AddMetadata, ModelPart
+from ..models.gemma3_model import (
+    Gemma3ForCausalLM,
+    Gemma3Config,
+    MODEL_DTYPE,
+    TEST_DEVICE,
+    CONTEXT_LENGTH,
+)
+
+
+class Gemma3Converter(BaseConverter):
+    """Handle conversion of Gemma 3 models to Core ML."""
+
+    model_cls = Gemma3ForCausalLM
+
+    def __init__(
+        self,
+        model: Gemma3ForCausalLM,
+        context_length: int = CONTEXT_LENGTH,
+        batch_size: int = 64,
+        lut_bits: int | None = 4,
+        per_channel: int = 8,
+        num_chunks: int = 1,
+    ) -> None:
+        super().__init__(model)
+        self.context_length = context_length
+        self.batch_size = batch_size
+        self.lut_bits = lut_bits
+        self.per_channel = per_channel
+        self.head_dim = (
+            model.model.config.hidden_size // model.model.config.num_attention_heads
+        )
+        self.converted_model = None
+        self.num_chunks = num_chunks
+
+    @staticmethod
+    def GetTransformerStates(model, part=None, prefix="model.model."):
+        """Get the transformer states for CoreML conversion"""
+        head_dim = getattr(
+            model.config,
+            "head_dim",
+            model.config.hidden_size // model.config.num_attention_heads,
+        )
+        num_layers = (
+            model.config.num_hidden_layers
+        )  # Get total number of layers from config
+
+        # For unified cache
+        num_layers_this_part = num_layers * 2
+        print(
+            f"GetTransformerStates part={part} num_layers_this_part={num_layers_this_part} model.config.num_hidden_layers={model.config.num_hidden_layers}"
+        )
+        print(f"Using head_dim={head_dim} from config")
+
+        states = [
+            ct.StateType(
+                wrapped_type=ct.TensorType(
+                    shape=(
+                        num_layers_this_part,
+                        model.config.num_key_value_heads,
+                        model.config.state_length,
+                        head_dim,
+                    ),
+                    dtype=np.float16,
+                ),
+                name=f"{prefix}kv_cache_0",  # Only one group for unified cache
+            )
+        ]
+        return states
+
+    def postprocess(self, num_workers=None):
+        """Apply LUT quantization if configured.
+
+        Args:
+            num_workers: Optional number of workers for parallel processing.
+                        If None, uses default single worker.
+        """
+        if self.converted_model is not None and self.lut_bits is not None:
+            print(
+                f"Applying LUT quantization with {self.lut_bits} bits and {self.per_channel} channels per group using {num_workers if num_workers else 1} worker(s)..."
+            )
+            try:
+                # Set up quantization config
+                config = cto.coreml.OptimizationConfig(
+                    global_config=cto.coreml.OpPalettizerConfig(
+                        mode="kmeans",
+                        nbits=self.lut_bits,
+                        granularity="per_grouped_channel",
+                        group_size=self.per_channel,
+                        num_kmeans_workers=(
+                            num_workers if num_workers is not None else 1
+                        ),  # Use provided workers or default to 1
+                    ),
+                )
+
+                # Apply quantization
+                self.converted_model = cto.coreml.palettize_weights(
+                    self.converted_model, config
+                )
+                print("✅ LUT quantization completed successfully")
+
+            except Exception as e:
+                print(f"❌ LUT quantization failed: {str(e)}")
+                print("Continuing without quantization...")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def convert(
+        self, part: str = "full"
+    ) -> ct.models.MLModel | List[ct.models.MLModel]:
+        """Convert the wrapped model to CoreML format.
+
+        Args:
+            part: Which part of the model to convert:
+                 "full" - complete model (default)
+                 "prefill" - prefill mode for initial sequence processing
+                 "embeddings" - embeddings only (input_ids -> hidden_states)
+
+        Returns:
+            ct.models.MLModel: Converted model
+        """
+        print(f"Gemma3Converter.convert() called with part={part}")
+        require_coreml()
+        print("Calling preprocess()...")
+        self.preprocess()
+
+        if part in ("full", "all", "123"):
+            print("Converting full model...")
+            mlmodel = self.convert_to_coreml(self.model)
+        elif part in ("embeddings", "1"):
+            print("Converting embeddings...")
+            mlmodel = self.convert_part_1(self.model)
+        elif part in ("prefill", "2_prefill"):
+            print("Converting prefill...")
+            if self.num_chunks > 1:
+                mlmodel = [
+                    self.convert_part_2_prefill(self.model, i, self.num_chunks)
+                    for i in range(self.num_chunks)
+                ]
+            else:
+                mlmodel = self.convert_part_2_prefill(self.model)
+        elif part == "2":
+            print("Converting FFN...")
+            if self.num_chunks > 1:
+                mlmodel = [
+                    self.convert_part_2(self.model, i, self.num_chunks)
+                    for i in range(self.num_chunks)
+                ]
+            else:
+                mlmodel = self.convert_part_2(self.model)
+        elif part == "3":
+            print("Converting LM head...")
+            mlmodel = self.convert_part_3(self.model)
+        else:
+            raise ValueError(f"Unsupported part: {part}")
+
+        print("Calling postprocess()...")
+        self.postprocess()
+        print("QwenConverter.convert() completed")
+        return mlmodel
+
+    def convert_to_coreml(self, model: Gemma3ForCausalLM) -> ct.models.MLModel:
+        """Convert the entire model to CoreML."""
+        require_coreml()
+        print("Creating wrapper model...")
+
+        class Wrapper(torch.nn.Module):
+            def __init__(self, model: Gemma3ForCausalLM, context_length: int) -> None:
+                super().__init__()
+                self.model = model
+                self.context_length = context_length
+
+            def forward(
+                self,
+                input_ids: torch.Tensor,
+                position_ids: torch.Tensor,
+                causal_mask: torch.Tensor,
+                current_pos: torch.Tensor,
+                update_mask: torch.Tensor,
+            ) -> torch.Tensor:
+                # Fixed window approach: return full logits, extract position on Python side
+                return self.model(
+                    input_ids=input_ids,
+                    update_mask=update_mask,
+                    position_ids=position_ids,
+                    causal_mask=causal_mask,
+                    current_pos=current_pos,
+                    IN_PREFILL=False,
+                )
+
+        wrapper = Wrapper(model, self.context_length)
+        wrapper.eval()
+        print("Wrapper model created and set to eval mode")
+
+        print("Preparing model inputs for tracing...")
+        # Use single token approach for KV cache compatibility
+        sample_input_ids = torch.zeros(
+            (1, 1), dtype=torch.int32, device=TEST_DEVICE
+        )  # [1, 1] - single token
+        sample_position_ids = torch.zeros(
+            (1,), dtype=torch.int32, device=TEST_DEVICE
+        )  # [1] - single position
+        sample_causal_mask = torch.zeros(
+            (1, 1, 1, self.context_length), dtype=torch.float16, device=TEST_DEVICE
+        )  # [1, 1, 1, context_length]
+        sample_current_pos = torch.zeros(
+            (1,), dtype=torch.int32, device=TEST_DEVICE
+        )  # [1] - current position
+        sample_update_mask = torch.zeros(
+            (1, 1, self.context_length, 1), dtype=torch.float16, device=TEST_DEVICE
+        )  # [1, 1, context_length, 1]
+        print("Sample inputs created (Single Token)")
+        print(f"sample_input_ids shape: {sample_input_ids.shape}")
+        print(f"sample_position_ids shape: {sample_position_ids.shape}")
+        print(f"sample_causal_mask shape: {sample_causal_mask.shape}")
+        print(f"sample_current_pos shape: {sample_current_pos.shape}")
+        print(f"sample_update_mask shape: {sample_update_mask.shape}")
+
+        print("Starting torch.jit.trace...")
+        traced = torch.jit.trace(
+            wrapper,
+            (
+                sample_input_ids,
+                sample_position_ids,
+                sample_causal_mask,
+                sample_current_pos,
+                sample_update_mask,
+            ),
+        )
+        print("torch.jit.trace completed!")
+
+        print("Starting CoreML conversion...")
+        mlmodel = ct.convert(
+            traced,
+            inputs=[
+                ct.TensorType(
+                    name="input_ids", shape=sample_input_ids.shape, dtype=np.int32
+                ),
+                ct.TensorType(
+                    name="position_ids", shape=sample_position_ids.shape, dtype=np.int32
+                ),
+                ct.TensorType(
+                    name="causal_mask", shape=sample_causal_mask.shape, dtype=np.float16
+                ),
+                ct.TensorType(
+                    name="current_pos", shape=sample_current_pos.shape, dtype=np.int32
+                ),
+                ct.TensorType(
+                    name="update_mask", shape=sample_update_mask.shape, dtype=np.float16
+                ),
+            ],
+            outputs=[
+                ct.TensorType(name="logits1", dtype=np.float16),
+                ct.TensorType(name="logits2", dtype=np.float16),
+                ct.TensorType(name="logits3", dtype=np.float16),
+                ct.TensorType(name="logits4", dtype=np.float16),
+                ct.TensorType(name="logits5", dtype=np.float16),
+                ct.TensorType(name="logits6", dtype=np.float16),
+                ct.TensorType(name="logits7", dtype=np.float16),
+                ct.TensorType(name="logits8", dtype=np.float16),
+                ct.TensorType(name="logits9", dtype=np.float16),
+                ct.TensorType(name="logits10", dtype=np.float16),
+                ct.TensorType(name="logits11", dtype=np.float16),
+                ct.TensorType(name="logits12", dtype=np.float16),
+                ct.TensorType(name="logits13", dtype=np.float16),
+                ct.TensorType(name="logits14", dtype=np.float16),
+                ct.TensorType(name="logits15", dtype=np.float16),
+                ct.TensorType(name="logits16", dtype=np.float16),
+            ],
+            states=self.GetTransformerStates(model, part=None, prefix="model.model."),
+            compute_precision=ct.precision.FLOAT16,
+            compute_units=ct.ComputeUnit.CPU_AND_NE,
+            minimum_deployment_target=ct.target.iOS18,
+            convert_to="mlprogram",
+        )
+        print("CoreML conversion completed!")
+
+        # Apply LUT quantization if specified
+        if self.lut_bits:
+            self.converted_model = mlmodel  # Set for postprocess
+            self.postprocess(num_workers=8)  # Allow passing num_workers if needed
+            mlmodel = self.converted_model
+
+        return mlmodel
+
+    # --------------------------------------------------------------
+    # Part-based conversion helpers
+    # --------------------------------------------------------------
+    def convert_part_1(self, model: Gemma3ForCausalLM) -> ct.models.MLModel:
+        """Convert embeddings layer only."""
+        require_coreml()
+        return self.convert_embeddings(model)
+
+    def convert_part_3(self, model: Gemma3ForCausalLM) -> ct.models.MLModel:
+        """Convert LM head only."""
+        require_coreml()
+
+        class LMHeadWrapper(torch.nn.Module):
+            def __init__(self, model: Gemma3ForCausalLM) -> None:
+                super().__init__()
+                if hasattr(model, "lm_head16_1"):
+                    self.heads = [
+                        getattr(model, f"lm_head16_{i}") for i in range(1, 17)
+                    ]
+                    self.mode = "16"
+                elif hasattr(model, "lm_head8_1"):
+                    self.heads = [getattr(model, f"lm_head8_{i}") for i in range(1, 9)]
+                    self.mode = "8"
+                elif hasattr(model, "lm_head2_1"):
+                    self.heads = [model.lm_head2_1, model.lm_head2_2]
+                    self.mode = "2"
+                elif hasattr(model, "lm_head1"):
+                    self.head = model.lm_head1
+                    self.mode = "1"
+                else:
+                    self.head = model.lm_head
+                    self.mode = "linear"
+
+            def forward(self, hidden_states: torch.Tensor):
+                if self.mode != "linear":
+                    hidden_states = hidden_states.permute(0, 2, 1).unsqueeze(2)
+
+                if self.mode == "16":
+                    return tuple(
+                        h(hidden_states).squeeze(2).transpose(1, 2) for h in self.heads
+                    )
+                if self.mode == "8":
+                    return tuple(
+                        h(hidden_states).squeeze(2).transpose(1, 2) for h in self.heads
+                    )
+                if self.mode == "2":
+                    logits1 = self.heads[0](hidden_states).squeeze(2).transpose(1, 2)
+                    logits2 = self.heads[1](hidden_states).squeeze(2).transpose(1, 2)
+                    return logits1, logits2
+                if self.mode == "1":
+                    return self.head(hidden_states).squeeze(2).transpose(1, 2)
+                return self.head(hidden_states)
+
+        wrapper = LMHeadWrapper(model)
+        wrapper.eval()
+        
+        # Ensure no gradients
+        for param in wrapper.parameters():
+            param.requires_grad = False
+
+        sample_input = torch.zeros(
+            (1, 1, model.config.hidden_size), dtype=MODEL_DTYPE, device=TEST_DEVICE
+        )
+        
+        # Trace with no_grad context
+        with torch.no_grad():
+            traced = torch.jit.trace(wrapper, sample_input)
+
+        if getattr(wrapper, "mode") == "16":
+            outputs = [
+                ct.TensorType(name=f"logits{i}", dtype=np.float16) for i in range(1, 17)
+            ]
+        elif getattr(wrapper, "mode") == "8":
+            outputs = [
+                ct.TensorType(name=f"logits{i}", dtype=np.float16) for i in range(1, 9)
+            ]
+        elif getattr(wrapper, "mode") == "2":
+            outputs = [
+                ct.TensorType(name="logits1", dtype=np.float16),
+                ct.TensorType(name="logits2", dtype=np.float16),
+            ]
+        else:
+            outputs = [ct.TensorType(name="logits", dtype=np.float16)]
+
+        mlmodel = ct.convert(
+            traced,
+            inputs=[
+                ct.TensorType(
+                    name="hidden_states", shape=sample_input.shape, dtype=np.float16
+                )
+            ],
+            outputs=outputs,
+            compute_precision=ct.precision.FLOAT16,
+            compute_units=ct.ComputeUnit.CPU_AND_NE,
+            minimum_deployment_target=ct.target.iOS18,
+            convert_to="mlprogram",
+        )
+
+        if self.lut_bits:
+            self.converted_model = mlmodel
+            self.postprocess(num_workers=8)
+            mlmodel = self.converted_model
+
+        return mlmodel
+
+    def convert_part_2(
+        self, model: Gemma3ForCausalLM, chunk_idx: int = 0, total_chunks: int = 1
+    ) -> ct.models.MLModel:
+        """Convert transformer layers for generation (FFN)."""
+        require_coreml()
+        total_layers = model.config.num_hidden_layers
+        if total_chunks > 1:
+            layers_per_chunk = total_layers // total_chunks
+            start_layer = chunk_idx * layers_per_chunk
+            end_layer = min((chunk_idx + 1) * layers_per_chunk, total_layers)
+        else:
+            start_layer = 0
+            end_layer = total_layers
+
+        class FFNWrapper(torch.nn.Module):
+            def __init__(self, model: Gemma3ForCausalLM) -> None:
+                super().__init__()
+                self.model = model.model  # Use the inner Gemma3TextModel
+                self.states = Gemma3Converter.GetTransformerStates(
+                    model, part="2", prefix="model.model."
+                )
+                self.layers_to_process = self.model.layers[start_layer:end_layer]
+                # Only apply final norm on the last chunk
+                self.final_norm = self.model.norm if end_layer == total_layers else None
+
+            def forward(self, hidden_states, position_ids, causal_mask, current_pos):
+                # For single-token generation, position_ids is a single value
+                # We need to get embeddings for this specific position
+                position_embeddings_global = self.model.rotary_emb(hidden_states, position_ids)
+                position_embeddings_local = self.model.rotary_emb_local(hidden_states, position_ids)
+
+                for decoder_layer in self.layers_to_process:
+                    # Determine which position embeddings to use based on the layer's attention type
+                    if decoder_layer.self_attn.is_sliding:
+                        position_embeddings = position_embeddings_local
+                    else:
+                        position_embeddings = position_embeddings_global
+                    
+                    # Call the decoder layer with the required positional arguments first
+                    layer_outputs = decoder_layer(
+                        hidden_states,
+                        position_embeddings,
+                        attention_mask=causal_mask,
+                        position_ids=position_ids,
+                    )
+                    hidden_states = layer_outputs[0]
+
+                if self.final_norm:
+                    hidden_states = self.final_norm(hidden_states)
+
+                return hidden_states
+
+        wrapper = FFNWrapper(model)
+        wrapper.eval()
+
+        hidden_states = torch.zeros(
+            (1, 1, model.config.hidden_size), dtype=torch.float16, device=TEST_DEVICE
+        )
+        position_ids = torch.zeros((1,), dtype=torch.int32, device=TEST_DEVICE)
+        causal_mask = torch.zeros(
+            (1, 1, 1, self.context_length), dtype=torch.float16, device=TEST_DEVICE
+        )
+        current_pos = torch.zeros((1,), dtype=torch.int32, device=TEST_DEVICE)
+
+        traced = torch.jit.trace(
+            wrapper, (hidden_states, position_ids, causal_mask, current_pos)
+        )
+
+        mlmodel = ct.convert(
+            traced,
+            inputs=[
+                ct.TensorType(
+                    name="hidden_states", shape=hidden_states.shape, dtype=np.float16
+                ),
+                ct.TensorType(
+                    name="position_ids", shape=position_ids.shape, dtype=np.int32
+                ),
+                ct.TensorType(
+                    name="causal_mask", shape=causal_mask.shape, dtype=np.float16
+                ),
+                ct.TensorType(
+                    name="current_pos", shape=current_pos.shape, dtype=np.int32
+                ),
+            ],
+            outputs=[ct.TensorType(name="output_hidden_states", dtype=np.float16)],
+            states=self.GetTransformerStates(model, part=None, prefix="model.model."),
+            compute_precision=ct.precision.FLOAT16,
+            compute_units=ct.ComputeUnit.CPU_AND_NE,
+            minimum_deployment_target=ct.target.iOS18,
+            convert_to="mlprogram",
+        )
+
+        if self.lut_bits:
+            self.converted_model = mlmodel
+            # WORKAROUND: CoreMLTools has a known bug where LUT quantization fails with multiple workers
+            # when processing chunked models. The second chunk quantization fails with "Pool not running".
+            # Setting workers to None (single-threaded) avoids this issue.
+            # TODO: File bug report with Apple CoreMLTools team about multi-worker quantization failure on chunked models
+            num_workers = None if total_chunks > 1 else 8
+            self.postprocess(num_workers=num_workers)
+            mlmodel = self.converted_model
+
+        return mlmodel
+
+    def convert_part_2_prefill(
+        self, model: Gemma3ForCausalLM, chunk_idx: int = 0, total_chunks: int = 1
+    ) -> ct.models.MLModel:
+        """Convert transformer layers for prefill mode."""
+        require_coreml()
+        total_layers = model.config.num_hidden_layers
+        if total_chunks > 1:
+            layers_per_chunk = total_layers // total_chunks
+            start_layer = chunk_idx * layers_per_chunk
+            end_layer = min((chunk_idx + 1) * layers_per_chunk, total_layers)
+        else:
+            start_layer = 0
+            end_layer = None
+
+        class PrefillWrapper(torch.nn.Module):
+            def __init__(self, model: Gemma3ForCausalLM, start_layer=0, end_layer=None):
+                super().__init__()
+                self.model = model  # Use Gemma3ForCausalLM as root
+                self.start_layer = start_layer
+                self.end_layer = end_layer
+                self.states = Gemma3Converter.GetTransformerStates(
+                    model, part="2_prefill", prefix="model.model."
+                )
+
+            def forward(self, hidden_states, position_ids, causal_mask, current_pos):
+                rotary = self.model.model.get_rotary_embedding_prefill(position_ids)
+                out = self.model.model.process_layers(
+                    hidden_states,
+                    position_ids,
+                    causal_mask,
+                    current_pos,
+                    rotary,
+                    start_layer=self.start_layer,
+                    end_layer=self.end_layer,
+                    IN_PREFILL=True,
+                )
+
+                # Skip normalization for prefill - data not used, only KV cache is updated!
+                # This follows the LLAMA pattern and avoids unnecessary computation
+                if self.end_layer is None or self.end_layer == len(self.model.model.layers):
+                    print("Skipping final normalization for prefill, data not used!")
+                    # Return only first token to minimize memory usage
+                    return out[:, 0:1, :]
+                
+                return out
+
+        wrapper = PrefillWrapper(model, start_layer, end_layer)
+        wrapper.eval()
+
+        # Check if this is the last chunk in a multi-chunk model
+        is_last_chunk = (chunk_idx == total_chunks - 1)
+        
+        hidden_states = torch.zeros(
+            (1, self.batch_size, model.config.hidden_size),
+            dtype=torch.float16,
+            device=TEST_DEVICE,
+        )
+        position_ids = torch.zeros(
+            (self.batch_size,), dtype=torch.int32, device=TEST_DEVICE
+        )
+        causal_mask = torch.zeros(
+            (1, 1, self.batch_size, self.context_length),
+            dtype=torch.float16,
+            device=TEST_DEVICE,
+        )
+        current_pos = torch.zeros((1,), dtype=torch.int32, device=TEST_DEVICE)
+
+        traced = torch.jit.trace(
+            wrapper, (hidden_states, position_ids, causal_mask, current_pos)
+        )
+
+        mlmodel = ct.convert(
+            traced,
+            inputs=[
+                ct.TensorType(
+                    name="hidden_states", shape=hidden_states.shape, dtype=np.float16
+                ),
+                ct.TensorType(
+                    name="position_ids", shape=position_ids.shape, dtype=np.int32
+                ),
+                ct.TensorType(
+                    name="causal_mask", shape=causal_mask.shape, dtype=np.float16
+                ),
+                ct.TensorType(
+                    name="current_pos", shape=current_pos.shape, dtype=np.int32
+                ),
+            ],
+            outputs=[ct.TensorType(name="output_hidden_states", dtype=np.float16)],
+            states=wrapper.states,
+            compute_precision=ct.precision.FLOAT16,
+            compute_units=ct.ComputeUnit.CPU_AND_NE,
+            minimum_deployment_target=ct.target.iOS18,
+            convert_to="mlprogram",
+        )
+
+        if self.lut_bits:
+            self.converted_model = mlmodel
+            # WORKAROUND: CoreMLTools has a known bug where LUT quantization fails with multiple workers
+            # when processing chunked models. The second chunk quantization fails with "Pool not running".
+            # Setting workers to None (single-threaded) avoids this issue.
+            # TODO: File bug report with Apple CoreMLTools team about multi-worker quantization failure on chunked models
+            num_workers = None if total_chunks > 1 else 8
+            self.postprocess(num_workers=num_workers)
+            mlmodel = self.converted_model
+
+        return mlmodel
+
+    def convert_prefill(self, model: Gemma3ForCausalLM) -> ct.models.MLModel:
+        """Convert Gemma3 model to CoreML format for prefill mode.
+
+        Args:
+            model: The Gemma3 model to convert
+
+        Returns:
+            ct.models.MLModel: Converted model for prefill processing
+        """
+        require_coreml()
+        print("Converting Gemma3 model for prefill mode...")
+
+        class PrefillWrapper(torch.nn.Module):
+            def __init__(
+                self, model: Gemma3ForCausalLM, context_length: int, batch_size: int
+            ) -> None:
+                super().__init__()
+                self.model = model
+                self.context_length = context_length
+                self.batch_size = batch_size
+
+            def forward(
+                self,
+                hidden_states: torch.Tensor,
+                position_ids: torch.Tensor,
+                causal_mask: torch.Tensor,
+                current_pos: torch.Tensor,
+            ) -> torch.Tensor:
+                # Prefill mode: only process transformer layers, skip embeddings and LM head
+                # This updates KV cache state without generating logits
+                return self.model.forward_prefill(
+                    hidden_states=hidden_states,
+                    position_ids=position_ids,
+                    causal_mask=causal_mask,
+                    current_pos=current_pos,
+                )
+
+        wrapper = PrefillWrapper(model, self.context_length, self.batch_size)
+        wrapper.eval()
+        print("Prefill wrapper model created and set to eval mode")
+
+        print("Preparing prefill model inputs for tracing...")
+        # Use batch_size for prefill mode (multiple tokens at once)
+        # Input is hidden_states instead of input_ids (skip embeddings)
+        sample_hidden_states = torch.zeros(
+            (1, self.batch_size, model.config.hidden_size),
+            dtype=torch.float16,
+            device=TEST_DEVICE,
+        )  # [1, batch_size, hidden_size]
+        sample_position_ids = torch.zeros(
+            (self.batch_size,), dtype=torch.int32, device=TEST_DEVICE
+        )  # [batch_size]
+        sample_causal_mask = torch.zeros(
+            (1, 1, self.batch_size, self.context_length),
+            dtype=torch.float16,
+            device=TEST_DEVICE,
+        )  # [1, 1, batch_size, context_length]
+        sample_current_pos = torch.zeros(
+            (1,), dtype=torch.int32, device=TEST_DEVICE
+        )  # [1] - current position
+
+        print("Prefill sample inputs created")
+        print(f"sample_hidden_states shape: {sample_hidden_states.shape}")
+        print(f"sample_position_ids shape: {sample_position_ids.shape}")
+        print(f"sample_causal_mask shape: {sample_causal_mask.shape}")
+        print(f"sample_current_pos shape: {sample_current_pos.shape}")
+
+        print("Starting torch.jit.trace for prefill...")
+        traced = torch.jit.trace(
+            wrapper,
+            (
+                sample_hidden_states,
+                sample_position_ids,
+                sample_causal_mask,
+                sample_current_pos,
+            ),
+        )
+        print("torch.jit.trace for prefill completed!")
+
+        print("Starting CoreML conversion for prefill...")
+        mlmodel = ct.convert(
+            traced,
+            inputs=[
+                ct.TensorType(
+                    name="hidden_states",
+                    shape=sample_hidden_states.shape,
+                    dtype=np.float16,
+                ),
+                ct.TensorType(
+                    name="position_ids", shape=sample_position_ids.shape, dtype=np.int32
+                ),
+                ct.TensorType(
+                    name="causal_mask", shape=sample_causal_mask.shape, dtype=np.float16
+                ),
+                ct.TensorType(
+                    name="current_pos", shape=sample_current_pos.shape, dtype=np.int32
+                ),
+            ],
+            outputs=[
+                ct.TensorType(
+                    name="output_hidden_states", dtype=np.float16
+                ),  # Only output hidden states, no logits
+            ],
+            states=self.GetTransformerStates(model, part=None, prefix="model.model."),
+            compute_precision=ct.precision.FLOAT16,
+            compute_units=ct.ComputeUnit.CPU_AND_NE,
+            minimum_deployment_target=ct.target.iOS18,
+            convert_to="mlprogram",
+        )
+        print("CoreML conversion for prefill completed!")
+
+        # Apply LUT quantization if specified
+        if self.lut_bits:
+            self.converted_model = mlmodel
+            self.postprocess(num_workers=8)  # Allow passing num_workers if needed
+            mlmodel = self.converted_model
+
+        return mlmodel
+
+    def convert_embeddings(self, model: Gemma3ForCausalLM) -> ct.models.MLModel:
+        """Convert embeddings layer to CoreML format.
+
+        Args:
+            model: The Gemma3 model containing embeddings
+
+        Returns:
+            ct.models.MLModel: Converted CoreML model for embeddings
+        """
+        require_coreml()
+        print("\nConverting Gemma3 embeddings layer...")
+
+        class EmbeddingsWrapper(torch.nn.Module):
+            def __init__(self, model):
+                super().__init__()
+                self.embed_tokens = model.model.embed_tokens
+
+            def forward(self, input_ids):
+                hidden_states = self.embed_tokens(input_ids)
+                return hidden_states.to(MODEL_DTYPE)
+
+        # Create wrapper and ensure eval mode
+        wrapper = EmbeddingsWrapper(model)
+        wrapper.eval()
+
+        # Create sample input for tracing
+        sample_input = torch.zeros((1, 1), dtype=torch.int32, device=TEST_DEVICE)
+
+        # Trace model
+        print("Tracing embeddings model...")
+        traced_model = torch.jit.trace(wrapper, sample_input)
+
+        # Define flexible input shapes for both single token and batch processing
+        input_shape = ct.EnumeratedShapes(
+            shapes=[
+                [1, 1],
+                [1, self.batch_size],
+            ],  # Support single token and batch_size tokens
+            default=[1, 1],  # Use single token as default
+        )
+
+        print(f"Converting embeddings model with input shape: {input_shape}")
+
+        # Convert to CoreML
+        mlmodel = ct.convert(
+            traced_model,
+            inputs=[
+                ct.TensorType(
+                    name="input_ids",
+                    shape=input_shape,  # Use enumerated shapes for flexibility
+                    dtype=np.int32,
+                )
+            ],
+            outputs=[ct.TensorType(name="hidden_states", dtype=np.float16)],
+            compute_precision=ct.precision.FLOAT16,
+            compute_units=ct.ComputeUnit.CPU_AND_NE,
+            minimum_deployment_target=ct.target.iOS18,
+            convert_to="mlprogram",
+        )
+
+        print("Embeddings conversion completed")
+
+        # Apply LUT quantization if specified
+        if self.lut_bits:
+            self.converted_model = mlmodel
+            self.postprocess(num_workers=8)  # Allow passing num_workers if needed
+            mlmodel = self.converted_model
+
+        return mlmodel
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments for the converter."""
+
+    parser = argparse.ArgumentParser(description="Convert Gemma3 model to CoreML format")
+
+    parser.add_argument(
+        "--model",
+        type=str,
+        help="Path to model directory (default: google/gemma3-1b-it)",
+    )
+    parser.add_argument(
+        "--prefix",
+        type=str,
+        default="gemma3",
+        help="Prefix for output filenames",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=64,
+        help="Batch size for prefill",
+    )
+    parser.add_argument(
+        "--context-length",
+        type=int,
+        default=CONTEXT_LENGTH,
+        help="Maximum context length",
+    )
+    parser.add_argument(
+        "--lut",
+        type=int,
+        default=None,
+        help="Use LUT quantization with N bits",
+    )
+    parser.add_argument(
+        "--chunk",
+        type=int,
+        default=None,
+        help="Split FFN/prefill into N chunks",
+    )
+    parser.add_argument(
+        "--part",
+        type=str,
+        choices=["1", "2", "2_prefill", "3", "all", "full", "prefill", "embeddings"],
+        default="all",
+        help="Model part to convert",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=".",
+        help="Output directory for converted models",
+    )
+
+    return parser.parse_args()
+
+
+def test_conversion(
+    model: Optional[Gemma3ForCausalLM] = None,
+    model_path: Optional[str] = None,
+    prefix: str = "gemma3",
+    context_length: int = CONTEXT_LENGTH,
+    lut_bits: Optional[int] = None,
+    batch_size: int = 64,
+    output_dir: str = ".",
+    part: str = "full",
+    num_chunks: int = 1,
+) -> ct.models.MLModel | List[ct.models.MLModel]:
+    """Convert a Gemma3 model and save the result.
+
+    Args:
+        model: Pre-loaded Qwen model (optional)
+        model_path: Path to model directory
+        prefix: Model name prefix
+        context_length: Context length for conversion
+        lut_bits: LUT quantization bits
+        batch_size: Batch size for conversion
+        output_dir: Output directory
+        part: Part to convert ("full" or "prefill")
+    """
+    print(
+        f"test_conversion called with model_path={model_path}, prefix={prefix}, part={part}"
+    )
+
+    if model is None:
+        if model_path is None:
+            raise ValueError("model_path must be provided if model is None")
+
+        config_path = os.path.join(model_path, "config.json")
+        print(f"Looking for config at: {config_path}")
+        if not os.path.exists(config_path):
+            raise ValueError(f"Config file not found at {config_path}")
+
+        print("Loading config...")
+        config = Gemma3Config.from_json(config_path)
+        print(
+            f"Config loaded: hidden_size={config.hidden_size}, vocab_size={config.vocab_size}"
+        )
+
+        # Update config to match conversion parameters
+        config.context_length = context_length
+        config.state_length = max(
+            config.state_length, context_length
+        )  # Ensure state_length is at least context_length
+        print(
+            f"Updated config: context_length={config.context_length}, state_length={config.state_length}"
+        )
+
+        print("Creating model...")
+        model = Gemma3ForCausalLM(config, enable_coreml=True)
+        print("Loading pretrained weights...")
+        model.load_pretrained_weights(model_path)
+        print("Model loaded successfully!")
+        
+        # Ensure model is in eval mode and gradients are disabled
+        model.eval()
+        for param in model.parameters():
+            param.requires_grad = False
+        print("Model set to eval mode and gradients disabled")
+
+    print("Creating converter...")
+    converter = Gemma3Converter(
+        model=model,
+        context_length=context_length,
+        batch_size=batch_size,
+        lut_bits=lut_bits,
+        num_chunks=num_chunks,
+    )
+
+    print("Starting conversion...")
+    mlmodel = converter.convert(part=part)
+    print("Conversion completed!")
+
+    print(f"Creating output directory: {output_dir}")
+    os.makedirs(output_dir, exist_ok=True)
+
+    if isinstance(mlmodel, list):
+        models = mlmodel
+    else:
+        models = [mlmodel]
+
+    for i, m in enumerate(models):
+        AddMetadata(
+            m,
+            {
+                "context_length": context_length,
+                "batch_size": batch_size if part in ["2_prefill", "prefill"] else None,
+                "lut_bits": lut_bits,
+                "num_chunks": num_chunks if part in ["2", "2_prefill"] else None,
+                "chunk_no": i + 1 if part in ["2", "2_prefill"] else None,
+                "split_part": (
+                    ModelPart.FULL.value if part in ["full", "all", "123"] else part
+                ),
+            },
+        )
+        fname = f"{prefix}"
+        if part in ["1", "embeddings"]:
+            fname += "_embeddings"
+        elif part in ["3"]:
+            fname += "_lm_head"
+        elif part in ["2", "2_prefill"]:
+            base = "FFN" if part == "2" else "prefill"
+            fname += f"_{base}"
+            if lut_bits is not None:
+                fname += f"_lut{lut_bits}"
+            fname += f"_chunk_{i+1:02d}of{num_chunks:02d}"
+        if part in ["full", "all", "123"]:
+            fname += ""
+        if part not in ["2", "2_prefill"]:
+            if lut_bits is not None:
+                fname += f"_lut{lut_bits}"
+            fname += ".mlpackage"
+        else:
+            fname += ".mlpackage"
+        out_path = os.path.join(output_dir, fname)
+        print(f"Saving model to: {out_path}")
+        m.save(out_path)
+
+    return mlmodel
+
+
+def main() -> None:
+    print("Starting gemma3_converter main()...")
+    args = parse_args()
+    print(f"Parsed args: {args}")
+
+    model_path = args.model if args.model else "google/gemma-3-1b-it"
+
+    print(f"\nConverting model from: {model_path}")
+    print(f"Output filename prefix: {args.prefix}")
+    print(f"Batch size: {args.batch_size}")
+    print(f"Context length: {args.context_length}")
+    if args.lut:
+        print(f"LUT quantization: {args.lut} bits")
+    if args.chunk:
+        print(f"Splitting into {args.chunk} chunks")
+    print(f"Converting part(s): {args.part}")
+
+    # Map legacy part names to numeric equivalents
+    part_map = {"full": "all", "embeddings": "1", "prefill": "2_prefill"}
+    part = part_map.get(args.part, args.part)
+
+    try:
+        print("\nCalling test_conversion()...")
+        result = test_conversion(
+            model_path=model_path,
+            prefix=args.prefix,
+            context_length=args.context_length,
+            lut_bits=args.lut,
+            batch_size=args.batch_size,
+            output_dir=args.output,
+            part=part,
+            num_chunks=args.chunk or 1,
+        )
+        print(f"Conversion completed successfully! Result: {type(result)}")
+    except Exception as e:  # pragma: no cover - CLI tool
+        print(f"\nError during conversion: {str(e)}")
+        import traceback
+
+        traceback.print_exc()
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -527,37 +527,37 @@ class Gemma3Converter(BaseConverter):
             start_layer = 0
             end_layer = None
 
-        class PrefillWrapper(torch.nn.Module):
-            def __init__(self, model: Gemma3ForCausalLM, start_layer=0, end_layer=None):
-                super().__init__()
-                self.model = model  # Use Gemma3ForCausalLM as root
-                self.start_layer = start_layer
-                self.end_layer = end_layer
-                self.states = Gemma3Converter.GetTransformerStates(
-                    model, part="2_prefill", prefix="model.model."
-                )
+class PrefillWrapper(torch.nn.Module):
 
-            def forward(self, hidden_states, position_ids, causal_mask, current_pos):
-                rotary = self.model.model.get_rotary_embedding_prefill(position_ids)
-                out = self.model.model.process_layers(
-                    hidden_states,
-                    position_ids,
-                    causal_mask,
-                    current_pos,
-                    rotary,
-                    start_layer=self.start_layer,
-                    end_layer=self.end_layer,
-                    IN_PREFILL=True,
-                )
+    def __init__(self, model: Gemma3ForCausalLM, start_layer=0, end_layer=None):
+        super().__init__()
+        self.model = model
+        self.start_layer = start_layer
+        self.end_layer = end_layer
+        self.layers = nn.ModuleList([
+            model.model.layers[i] for i in range(start_layer, end_layer)
+        ])
+    
+    def forward(self, hidden_states, position_ids, causal_mask, current_pos):
+        cos_global, sin_global, cos_local, sin_local = self.model.model.get_rotary_embedding_prefill(position_ids)
 
-                # Skip normalization for prefill - data not used, only KV cache is updated!
-                # This follows the LLAMA pattern and avoids unnecessary computation
-                if self.end_layer is None or self.end_layer == len(self.model.model.layers):
-                    print("Skipping final normalization for prefill, data not used!")
-                    # Return only first token to minimize memory usage
-                    return out[:, 0:1, :]
-                
-                return out
+        for decoder_layer in self.layers:
+            if decoder_layer.self_attn.is_sliding:
+                position_embeddings = (cos_local, sin_local)
+            else:
+                position_embeddings = (cos_global, sin_global)
+
+            layer_outputs = decoder_layer(
+                hidden_states,
+                position_embeddings=position_embeddings,
+                attention_mask=causal_mask,
+                position_ids=position_ids,
+                use_cache=True,
+                cache_position=current_pos,
+            )
+            hidden_states = layer_outputs[0]
+
+        return hidden_states, self.model.model.get_transformer_states()
 
         wrapper = PrefillWrapper(model, start_layer, end_layer)
         wrapper.eval()
@@ -601,7 +601,8 @@ class Gemma3Converter(BaseConverter):
                 ),
             ],
             outputs=[ct.TensorType(name="output_hidden_states", dtype=np.float16)],
-            states=wrapper.states,
+            #states=wrapper.states,
+            states=self.GetTransformerStates(model, part="2_prefill", prefix="model.model."),
             compute_precision=ct.precision.FLOAT16,
             compute_units=ct.ComputeUnit.CPU_AND_NE,
             minimum_deployment_target=ct.target.iOS18,

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -84,7 +84,8 @@ class Gemma3Converter(BaseConverter):
                     ),
                     dtype=np.float16,
                 ),
-                name=f"{prefix}kv_cache_0",  # Only one group for unified cache
+                #name=f"{prefix}kv_cache_0",  # Only one group for unified cache
+                name=f"kv_cache_0"
             )
         ]
         return states
@@ -609,45 +610,38 @@ class Gemma3Converter(BaseConverter):
                 sample_causal_mask,
                 sample_current_pos,
             ),
-        )
-
-        mlmodel = ct.convert(
-            traced,
-            inputs=[
-                ct.TensorType(
-                    name="hidden_states", shape=sample_hidden_states.shape, dtype=np.float16
-                ),
-                ct.TensorType(
-                    name="position_ids", shape=sample_position_ids.shape, dtype=np.int32
-                ),
-                ct.TensorType(
-                    name="causal_mask", shape=sample_causal_mask.shape, dtype=np.float16
-                ),
-                ct.TensorType(
-                    name="current_pos", shape=sample_current_pos.shape, dtype=np.int32
-                ),
-            ],
-            outputs=[
-                ct.TensorType(name="output_hidden_states", dtype=np.float16),
-                ct.TensorType(
-                    name="kv_cache_output",
-                    shape=(
-                        2 * model.config.num_hidden_layers,
-                        self.context_length,
-                        model.config.num_key_value_heads,
-                        model.config.head_dim
-                    ),
-                    dtype=np.float16,
-                ),
-            ],
-            states=self.GetTransformerStates(model, part="2_prefill", prefix="model.model."),
-            compute_precision=ct.precision.FLOAT16,
-            compute_units=ct.ComputeUnit.CPU_AND_NE,
-            minimum_deployment_target=ct.target.iOS18,
-            convert_to="mlprogram",
-        )
+        ) 
         
+        mlmodel = ct.convert(
+          traced,
+          inputs=[
+        ct.TensorType(
+            name="hidden_states", shape=sample_hidden_states.shape, dtype=np.float16
+        ),
+        ct.TensorType(
+            name="position_ids", shape=sample_position_ids.shape, dtype=np.int32
+        ),
+        ct.TensorType(
+            name="causal_mask", shape=sample_causal_mask.shape, dtype=np.float16
+        ),
+        ct.TensorType(
+            name="current_pos", shape=sample_current_pos.shape, dtype=np.int32
+        ),
+        ],
+        outputs=[
+        ct.TensorType(name="output_hidden_states", dtype=np.float16),
+        ct.TensorType(name="kv_cache_output", dtype=np.float16),
+        ],
+        states=self.GetTransformerStates(model, part="2_prefill", prefix="model.model."),
+        compute_precision=ct.precision.FLOAT16,
+        compute_units=ct.ComputeUnit.CPU_AND_NE,
+        minimum_deployment_target=ct.target.iOS18,
+        convert_to="mlprogram",
+    )
         return mlmodel
+
+
+    
     
 class PrefillWrapper(torch.nn.Module):
 
@@ -1043,6 +1037,8 @@ def test_conversion(
 
         print("Creating model...")
         model = Gemma3ForCausalLM(config, enable_coreml=True)
+        for i in range(model.config.num_hidden_layers):
+            model.register_buffer(f"kv_cache_{i}", None)
         print("Loading pretrained weights...")
         model.load_pretrained_weights(model_path)
         print("Model loaded successfully!")

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -553,6 +553,9 @@ class Gemma3Converter(BaseConverter):
                     hidden_states, position_ids, seq_len=position_ids.shape[1]
                 )
                 
+                
+                key_value_cache_list = []
+
                 for decoder_layer in self.layers:
                     if decoder_layer.self_attn.is_sliding:
                         position_embeddings = (cos_local, sin_local)
@@ -569,15 +572,16 @@ class Gemma3Converter(BaseConverter):
                         cache_position=current_pos,
                     )
                     hidden_states = layer_outputs[0]
+                   
+                    key_value_cache_list.append(layer_outputs[1])
 
                 # The Prefill wrapper MUST return a tuple of (output, state)
-                return hidden_states, tuple(
-                    layer_outputs[1].split(
-                        model.model.config.hidden_size, dim=-1
-                    )
-                    for layer_outputs in hidden_states.shape[0]
-                )
+               
+                return hidden_states, tuple(key_value_cache_list)
 
+
+        wrapper = PrefillWrapper(model, start_layer, end_layer)
+        wrapper.eval()
 
         wrapper = PrefillWrapper(model, start_layer, end_layer)
         wrapper.eval()

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -84,8 +84,7 @@ class Gemma3Converter(BaseConverter):
                     ),
                     dtype=np.float16,
                 ),
-                #name=f"{prefix}kv_cache_0",  # Only one group for unified cache
-                name=f"kv_cache_0"
+                name=f"{prefix}kv_cache_0",  # Only one group for unified cache
             )
         ]
         return states
@@ -532,20 +531,37 @@ class Gemma3Converter(BaseConverter):
               f"({start_layer}-{end_layer})")
 
         class PrefillWrapper(torch.nn.Module):
-            def __init__(self, model: Gemma3ForCausalLM, start_layer: int, end_layer: int) -> None:
+            def __init__(self, model: Gemma3ForCausalLM, start_layer: int, end_layer: int, context_length: int) -> None:
                 super().__init__()
                 self.layers = nn.ModuleList([
                     model.model.layers[i] for i in range(start_layer, end_layer)
                 ])
                 self.rotary_emb_local = model.model.rotary_emb_local
                 self.rotary_emb_global = model.model.rotary_emb
-            
+                self.states = []
+
+                head_dim = model.config.hidden_size // model.config.num_attention_heads
+                num_layers_in_chunk = end_layer - start_layer
+
+                for i in range(num_layers_in_chunk):
+                    layer_idx = start_layer + i
+                    # Register buffer for each state
+                    buffer_name = f"kv_cache_{layer_idx}"
+                    buffer_shape = (1, context_length, model.config.num_key_value_heads, head_dim)
+                    self.register_buffer(
+                        buffer_name,
+                        torch.zeros(buffer_shape, dtype=torch.float16)
+                    )
+                    # Append StateType with shape
+                    self.states.append(ct.StateType(name=buffer_name, wrapped_type=ct.TensorType(shape=buffer_shape)))
+
             def forward(
                 self,
                 hidden_states: torch.Tensor,
                 position_ids: torch.Tensor,
                 causal_mask: torch.Tensor,
                 current_pos: torch.Tensor,
+                *past_key_values
             ):
                 cos_global, sin_global = self.rotary_emb_global(
                     hidden_states, position_ids, seq_len=position_ids.shape[1]
@@ -557,7 +573,7 @@ class Gemma3Converter(BaseConverter):
                 
                 key_value_cache_list = []
 
-                for decoder_layer in self.layers:
+                for i, decoder_layer in enumerate(self.layers):
                     if decoder_layer.self_attn.is_sliding:
                         position_embeddings = (cos_local, sin_local)
                     else:
@@ -571,6 +587,7 @@ class Gemma3Converter(BaseConverter):
                         position_ids=position_ids,
                         use_cache=True,
                         cache_position=current_pos,
+                        past_key_value=past_key_values[i]
                     )
                     hidden_states = layer_outputs[0]
                    
@@ -578,13 +595,10 @@ class Gemma3Converter(BaseConverter):
 
                 # The Prefill wrapper MUST return a tuple of (output, state)
                
-                return hidden_states, tuple(key_value_cache_list)
+                return (hidden_states, *key_value_cache_list)
 
 
-        wrapper = PrefillWrapper(model, start_layer, end_layer)
-        wrapper.eval()
-
-        wrapper = PrefillWrapper(model, start_layer, end_layer)
+        wrapper = PrefillWrapper(model, start_layer, end_layer, self.context_length)
         wrapper.eval()
 
         sample_hidden_states = torch.zeros(
@@ -602,6 +616,17 @@ class Gemma3Converter(BaseConverter):
         )
         sample_current_pos = torch.zeros((1,), dtype=torch.int32, device=TEST_DEVICE)
 
+        num_layers_in_chunk = end_layer - start_layer
+        head_dim = model.config.hidden_size // model.config.num_attention_heads
+        sample_past_key_values = tuple(
+            torch.zeros(
+                (1, self.context_length, model.config.num_key_value_heads, head_dim),
+                dtype=torch.float16,
+                device=TEST_DEVICE,
+            )
+            for _ in range(num_layers_in_chunk)
+        )
+
         traced = torch.jit.trace(
             wrapper,
             (
@@ -609,134 +634,47 @@ class Gemma3Converter(BaseConverter):
                 sample_position_ids,
                 sample_causal_mask,
                 sample_current_pos,
+                *sample_past_key_values
             ),
-        ) 
-        
-        mlmodel = ct.convert(
-          traced,
-          inputs=[
-        ct.TensorType(
-            name="hidden_states", shape=sample_hidden_states.shape, dtype=np.float16
-        ),
-        ct.TensorType(
-            name="position_ids", shape=sample_position_ids.shape, dtype=np.int32
-        ),
-        ct.TensorType(
-            name="causal_mask", shape=sample_causal_mask.shape, dtype=np.float16
-        ),
-        ct.TensorType(
-            name="current_pos", shape=sample_current_pos.shape, dtype=np.int32
-        ),
-        ],
-        outputs=[
-        ct.TensorType(name="output_hidden_states", dtype=np.float16),
-        ct.TensorType(name="kv_cache_output", dtype=np.float16),
-        ],
-        states=self.GetTransformerStates(model, part="2_prefill", prefix="model.model."),
-        compute_precision=ct.precision.FLOAT16,
-        compute_units=ct.ComputeUnit.CPU_AND_NE,
-        minimum_deployment_target=ct.target.iOS18,
-        convert_to="mlprogram",
-    )
-        return mlmodel
+        )
 
-
-    
-    
-class PrefillWrapper(torch.nn.Module):
-
-    def __init__(self, model: Gemma3ForCausalLM, start_layer=0, end_layer=None):
-        super().__init__()
-        self.model = model
-        self.start_layer = start_layer
-        self.end_layer = end_layer
-        self.layers = nn.ModuleList([
-            model.model.layers[i] for i in range(start_layer, end_layer)
+        inputs = [
+            ct.TensorType(
+                name="hidden_states", shape=sample_hidden_states.shape, dtype=np.float16
+            ),
+            ct.TensorType(
+                name="position_ids", shape=sample_position_ids.shape, dtype=np.int32
+            ),
+            ct.TensorType(
+                name="causal_mask", shape=sample_causal_mask.shape, dtype=np.float16
+            ),
+            ct.TensorType(
+                name="current_pos", shape=sample_current_pos.shape, dtype=np.int32
+            ),
+        ]
+        inputs.extend([
+            ct.TensorType(name=f"kv_cache_{i}_in", shape=sample_past_key_values[i-start_layer].shape, dtype=np.float16)
+            for i in range(start_layer, end_layer)
         ])
-    
-    def forward(self, hidden_states, position_ids, causal_mask, current_pos):
-        cos_global, sin_global, cos_local, sin_local = self.model.model.get_rotary_embedding_prefill(position_ids)
 
-        for decoder_layer in self.layers:
-            if decoder_layer.self_attn.is_sliding:
-                position_embeddings = (cos_local, sin_local)
-            else:
-                position_embeddings = (cos_global, sin_global)
-
-            layer_outputs = decoder_layer(
-                hidden_states,
-                position_embeddings=position_embeddings,
-                attention_mask=causal_mask,
-                position_ids=position_ids,
-                use_cache=True,
-                cache_position=current_pos,
-            )
-            hidden_states = layer_outputs[0]
-
-        return hidden_states, self.model.model.get_transformer_states()
-
-        wrapper = PrefillWrapper(model, start_layer, end_layer)
-        wrapper.eval()
-
-        # Check if this is the last chunk in a multi-chunk model
-        is_last_chunk = (chunk_idx == total_chunks - 1)
-        
-        hidden_states = torch.zeros(
-            (1, self.batch_size, model.config.hidden_size),
-            dtype=torch.float16,
-            device=TEST_DEVICE,
-        )
-        position_ids = torch.zeros(
-            (self.batch_size,), dtype=torch.int32, device=TEST_DEVICE
-        )
-        causal_mask = torch.zeros(
-            (1, 1, self.batch_size, self.context_length),
-            dtype=torch.float16,
-            device=TEST_DEVICE,
-        )
-        current_pos = torch.zeros((1,), dtype=torch.int32, device=TEST_DEVICE)
-
-        traced = torch.jit.trace(
-            wrapper, (hidden_states, position_ids, causal_mask, current_pos)
-        )
+        outputs = [ct.TensorType(name="output_hidden_states", dtype=np.float16)]
+        for i in range(start_layer, end_layer):
+            outputs.append(ct.TensorType(name=f"key_cache_{i}_out", dtype=np.float16))
+            outputs.append(ct.TensorType(name=f"value_cache_{i}_out", dtype=np.float16))
 
         mlmodel = ct.convert(
             traced,
-            inputs=[
-                ct.TensorType(
-                    name="hidden_states", shape=hidden_states.shape, dtype=np.float16
-                ),
-                ct.TensorType(
-                    name="position_ids", shape=position_ids.shape, dtype=np.int32
-                ),
-                ct.TensorType(
-                    name="causal_mask", shape=causal_mask.shape, dtype=np.float16
-                ),
-                ct.TensorType(
-                    name="current_pos", shape=current_pos.shape, dtype=np.int32
-                ),
-            ],
-            outputs=[ct.TensorType(name="output_hidden_states", dtype=np.float16)],
-            #states=wrapper.states,
-            states=self.GetTransformerStates(model, part="2_prefill", prefix="model.model."),
+            inputs=inputs,
+            outputs=outputs,
+            states=wrapper.states,
             compute_precision=ct.precision.FLOAT16,
             compute_units=ct.ComputeUnit.CPU_AND_NE,
             minimum_deployment_target=ct.target.iOS18,
             convert_to="mlprogram",
         )
-
-        if self.lut_bits:
-            self.converted_model = mlmodel
-            # WORKAROUND: CoreMLTools has a known bug where LUT quantization fails with multiple workers
-            # when processing chunked models. The second chunk quantization fails with "Pool not running".
-            # Setting workers to None (single-threaded) avoids this issue.
-            # TODO: File bug report with Apple CoreMLTools team about multi-worker quantization failure on chunked models
-            num_workers = None if total_chunks > 1 else 8
-            self.postprocess(num_workers=num_workers)
-            mlmodel = self.converted_model
-
+        
         return mlmodel
-
+    
     def convert_prefill(self, model: Gemma3ForCausalLM) -> ct.models.MLModel:
         """Convert Gemma3 model to CoreML format for prefill mode.
 
@@ -1037,8 +975,6 @@ def test_conversion(
 
         print("Creating model...")
         model = Gemma3ForCausalLM(config, enable_coreml=True)
-        for i in range(model.config.num_hidden_layers):
-            model.register_buffer(f"kv_cache_{i}", None)
         print("Loading pretrained weights...")
         model.load_pretrained_weights(model_path)
         print("Model loaded successfully!")

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -591,7 +591,8 @@ class Gemma3Converter(BaseConverter):
                     )
                     hidden_states = layer_outputs[0]
                    
-                    key_value_cache_list.append(layer_outputs[1])
+                    key_value_cache_list.append(layer_outputs[1][0])
+                    key_value_cache_list.append(layer_outputs[1][1])
 
                 # The Prefill wrapper MUST return a tuple of (output, state)
                
@@ -658,15 +659,19 @@ class Gemma3Converter(BaseConverter):
         ])
 
         outputs = [ct.TensorType(name="output_hidden_states", dtype=np.float16)]
-        for i in range(start_layer, end_layer):
-            outputs.append(ct.TensorType(name=f"key_cache_{i}_out", dtype=np.float16))
-            outputs.append(ct.TensorType(name=f"value_cache_{i}_out", dtype=np.float16))
+        outputs.extend([
+            ct.TensorType(name=f"key_cache_{start_layer + i}_out", dtype=np.float16)
+            for i in range(num_layers_in_chunk)
+        ])
+        outputs.extend([
+            ct.TensorType(name=f"value_cache_{start_layer + i}_out", dtype=np.float16)
+            for i in range(num_layers_in_chunk)
+        ])
 
         mlmodel = ct.convert(
             traced,
             inputs=inputs,
             outputs=outputs,
-            states=wrapper.states,
             compute_precision=ct.precision.FLOAT16,
             compute_units=ct.ComputeUnit.CPU_AND_NE,
             minimum_deployment_target=ct.target.iOS18,

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -463,7 +463,7 @@ class Gemma3Converter(BaseConverter):
         hidden_states = torch.zeros(
             (1, 1, model.config.hidden_size), dtype=torch.float16, device=TEST_DEVICE
         )
-        position_ids = torch.zeros((1, 1), dtype=torch.int32, device=TEST_DEVICE)
+        position_ids = torch.zeros((1, ), dtype=torch.int32, device=TEST_DEVICE)
         causal_mask = torch.zeros(
             (1, 1, 1, self.context_length), dtype=torch.float16, device=TEST_DEVICE
         )
@@ -680,125 +680,7 @@ class Gemma3Converter(BaseConverter):
         
         return mlmodel
         
-    # don't use this
-    def convert_prefill(self, model: Gemma3ForCausalLM) -> ct.models.MLModel:
-        """Convert Gemma3 model to CoreML format for prefill mode.
-
-        Args:
-            model: The Gemma3 model to convert
-
-        Returns:
-            ct.models.MLModel: Converted model for prefill processing
-        """
-        require_coreml()
-        print("Converting Gemma3 model for prefill mode...")
-
-        class PrefillWrapper(torch.nn.Module):
-            def __init__(
-                self, model: Gemma3ForCausalLM, context_length: int, batch_size: int
-            ) -> None:
-                super().__init__()
-                self.model = model
-                self.context_length = context_length
-                self.batch_size = batch_size
-
-            def forward(
-                self,
-                hidden_states: torch.Tensor,
-                position_ids: torch.Tensor,
-                causal_mask: torch.Tensor,
-                current_pos: torch.Tensor,
-            ) -> torch.Tensor:
-                # Prefill mode: only process transformer layers, skip embeddings and LM head
-                # This updates KV cache state without generating logits
-                return self.model.forward_prefill(
-                    hidden_states=hidden_states,
-                    position_ids=position_ids,
-                    causal_mask=causal_mask,
-                    current_pos=current_pos,
-                )
-
-        wrapper = PrefillWrapper(model, self.context_length, self.batch_size)
-        wrapper.eval()
-        print("Prefill wrapper model created and set to eval mode")
-
-        print("Preparing prefill model inputs for tracing...")
-        # Use batch_size for prefill mode (multiple tokens at once)
-        # Input is hidden_states instead of input_ids (skip embeddings)
-        sample_hidden_states = torch.zeros(
-            (1, self.batch_size, model.config.hidden_size),
-            dtype=torch.float16,
-            device=TEST_DEVICE,
-        )  # [1, batch_size, hidden_size]
-        sample_position_ids = torch.zeros(
-            (self.batch_size,), dtype=torch.int32, device=TEST_DEVICE
-        )  # [batch_size]
-        sample_causal_mask = torch.zeros(
-            (1, 1, self.batch_size, self.context_length),
-            dtype=torch.float16,
-            device=TEST_DEVICE,
-        )  # [1, 1, batch_size, context_length]
-        sample_current_pos = torch.zeros(
-            (1,), dtype=torch.int32, device=TEST_DEVICE
-        )  # [1] - current position
-
-        print("Prefill sample inputs created")
-        print(f"sample_hidden_states shape: {sample_hidden_states.shape}")
-        print(f"sample_position_ids shape: {sample_position_ids.shape}")
-        print(f"sample_causal_mask shape: {sample_causal_mask.shape}")
-        print(f"sample_current_pos shape: {sample_current_pos.shape}")
-
-        print("Starting torch.jit.trace for prefill...")
-        traced = torch.jit.trace(
-            wrapper,
-            (
-                sample_hidden_states,
-                sample_position_ids,
-                sample_causal_mask,
-                sample_current_pos,
-            ),
-        )
-        print("torch.jit.trace for prefill completed!")
-
-        print("Starting CoreML conversion for prefill...")
-        mlmodel = ct.convert(
-            traced,
-            inputs=[
-                ct.TensorType(
-                    name="hidden_states",
-                    shape=sample_hidden_states.shape,
-                    dtype=np.float16,
-                ),
-                ct.TensorType(
-                    name="position_ids", shape=sample_position_ids.shape, dtype=np.int32
-                ),
-                ct.TensorType(
-                    name="causal_mask", shape=sample_causal_mask.shape, dtype=np.float16
-                ),
-                ct.TensorType(
-                    name="current_pos", shape=sample_current_pos.shape, dtype=np.int32
-                ),
-            ],
-            outputs=[
-                ct.TensorType(
-                    name="output_hidden_states", dtype=np.float16
-                ),  # Only output hidden states, no logits
-            ],
-            states=self.GetTransformerStates(model, part=None, prefix="model.model."),
-            compute_precision=ct.precision.FLOAT16,
-            compute_units=ct.ComputeUnit.CPU_AND_NE,
-            minimum_deployment_target=ct.target.iOS18,
-            convert_to="mlprogram",
-        )
-        print("CoreML conversion for prefill completed!")
-
-        # Apply LUT quantization if specified
-        if self.lut_bits:
-            self.converted_model = mlmodel
-            self.postprocess(num_workers=8)  # Allow passing num_workers if needed
-            mlmodel = self.converted_model
-
-        return mlmodel
+    
 
     def convert_embeddings(self, model: Gemma3ForCausalLM) -> ct.models.MLModel:
         """Convert embeddings layer to CoreML format.
@@ -834,14 +716,14 @@ class Gemma3Converter(BaseConverter):
         traced_model = torch.jit.trace(wrapper, sample_input)
 
         # Define enumerated input shapes for flexibility
-        #input_shape = ct.EnumeratedShapes(
-            #shapes=[
-                #[1, 1],
-                #[1, self.context_length],
-                #[1, 64],
-            #],  
-            #default=[1, self.context_length],  
-        #)
+        input_shape = ct.EnumeratedShapes(
+            shapes=[
+                [1, 1],
+                [1, self.context_length],
+                
+            ],  
+            default=[1, self.context_length],  
+        )
 
         print(f"Converting embeddings model with input shape: {input_shape}")
 
@@ -851,7 +733,7 @@ class Gemma3Converter(BaseConverter):
             inputs=[
                 ct.TensorType(
                     name="input_ids",
-                    shape=sample_input.shape, 
+                    shape=input_shape, 
                     dtype=np.int32,
                 )
             ],

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -846,7 +846,7 @@ class Gemma3Converter(BaseConverter):
         # Define enumerated input shapes for flexibility
         input_shape = ct.EnumeratedShapes(
             shapes=[
-                
+                [1, 1]
                 [1, self.context_length],
             ],  
             default=[1, self.context_length],  

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -14,6 +14,7 @@ import numpy as np
 import torch
 import coremltools as ct
 import coremltools.optimize as cto
+import torch.nn as nn
 
 from .environment import require_coreml
 
@@ -177,7 +178,7 @@ class Gemma3Converter(BaseConverter):
 
         print("Calling postprocess()...")
         self.postprocess()
-        print("QwenConverter.convert() completed")
+        print("Gemma3Converter.convert() completed")
         return mlmodel
 
     def convert_to_coreml(self, model: Gemma3ForCausalLM) -> ct.models.MLModel:
@@ -424,44 +425,43 @@ class Gemma3Converter(BaseConverter):
             end_layer = total_layers
 
         class FFNWrapper(torch.nn.Module):
-            def __init__(self, model: Gemma3ForCausalLM) -> None:
+            def __init__(self, model: Gemma3ForCausalLM, start_layer, end_layer) -> None:
                 super().__init__()
-                self.model = model.model  # Use the inner Gemma3TextModel
-                self.states = Gemma3Converter.GetTransformerStates(
-                    model, part="2", prefix="model.model."
-                )
-                self.layers_to_process = self.model.layers[start_layer:end_layer]
-                # Only apply final norm on the last chunk
-                self.final_norm = self.model.norm if end_layer == total_layers else None
+                self.model = model
+                self.layers = nn.ModuleList([
+                    model.model.layers[i] for i in range(start_layer, end_layer)
+                ])
+                self.norm = model.model.norm
+                #self.layers_to_process = self.model.layers[start_layer:end_layer]
+                self.rotary_emb_local = model.model.rotary_emb_local 
+                self.rotary_emb_global = model.model.rotary_emb  
 
             def forward(self, hidden_states, position_ids, causal_mask, current_pos):
-                # For single-token generation, position_ids is a single value
-                # We need to get embeddings for this specific position
-                position_embeddings_global = self.model.rotary_emb(hidden_states, position_ids)
-                position_embeddings_local = self.model.rotary_emb_local(hidden_states, position_ids)
-
-                for decoder_layer in self.layers_to_process:
-                    # Determine which position embeddings to use based on the layer's attention type
+                position_embeddings_global = self.rotary_emb_global(hidden_states, position_ids)
+                position_embeddings_local = self.rotary_emb_local(hidden_states, position_ids)
+                
+                for decoder_layer in self.layers:
                     if decoder_layer.self_attn.is_sliding:
                         position_embeddings = position_embeddings_local
                     else:
                         position_embeddings = position_embeddings_global
-                    
-                    # Call the decoder layer with the required positional arguments first
+
                     layer_outputs = decoder_layer(
                         hidden_states,
-                        position_embeddings,
+                        position_embeddings=position_embeddings,
                         attention_mask=causal_mask,
                         position_ids=position_ids,
+                        use_cache=True,
+                        cache_position=current_pos,
                     )
                     hidden_states = layer_outputs[0]
 
-                if self.final_norm:
-                    hidden_states = self.final_norm(hidden_states)
+                hidden_states = self.norm(hidden_states)
 
                 return hidden_states
 
-        wrapper = FFNWrapper(model)
+
+        wrapper = FFNWrapper(model, start_layer, end_layer)
         wrapper.eval()
 
         hidden_states = torch.zeros(
@@ -494,7 +494,7 @@ class Gemma3Converter(BaseConverter):
                 ),
             ],
             outputs=[ct.TensorType(name="output_hidden_states", dtype=np.float16)],
-            states=self.GetTransformerStates(model, part=None, prefix="model.model."),
+            #states=self.GetTransformerStates(model, part=None, prefix="model.model."),
             compute_precision=ct.precision.FLOAT16,
             compute_units=ct.ComputeUnit.CPU_AND_NE,
             minimum_deployment_target=ct.target.iOS18,
@@ -923,6 +923,9 @@ def test_conversion(
         print("Loading pretrained weights...")
         model.load_pretrained_weights(model_path)
         print("Model loaded successfully!")
+
+        model.to(MODEL_DTYPE)
+        print("Model has been converted to MODEL_DTYPE for CoreML conversion.")
         
         # Ensure model is in eval mode and gradients are disabled
         model.eval()
@@ -1035,4 +1038,5 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
 

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -122,7 +122,7 @@ class Gemma3Converter(BaseConverter):
 
             except Exception as e:
                 print(f"❌ LUT quantization failed: {str(e)}")
-                print("Continuing without quantization...")
+             
 
     # ------------------------------------------------------------------
     # Public API
@@ -343,6 +343,7 @@ class Gemma3Converter(BaseConverter):
                     hidden_states = hidden_states.permute(0, 2, 1).unsqueeze(2)
 
                 if self.mode == "16":
+                    # Do not specify `shape` for outputs; coremltools infers it
                     return tuple(
                         h(hidden_states).squeeze(2).transpose(1, 2) for h in self.heads
                     )
@@ -374,28 +375,19 @@ class Gemma3Converter(BaseConverter):
             traced = torch.jit.trace(wrapper, sample_input)
 
         if getattr(wrapper, "mode") == "16":
-            outputs = [
-                ct.TensorType(
-                    name=f"logits{i}",
-                    shape=(1, self.context_length, model.config.vocab_size),
-                    dtype=np.float16,
-                ) for i in range(1, 17)       
-            ]
+            # Do not specify `shape` for outputs; coremltools infers it
+            outputs = [ct.TensorType(name=f"logits{i}", dtype=np.float16) for i in range(1, 17)]
+
         elif getattr(wrapper, "mode") == "8":
-            outputs = [
-                ct.TensorType(
-                    name=f"logits{i}",
-                    shape=(1, self.context_length, model.config.vocab_size),
-                    dtype=np.float16,
-                ) for i in range(1, 9)       
-            ]
+            outputs = [ct.TensorType(name=f"logits{i}", dtype=np.float16) for i in range(1, 9)]
+
         elif getattr(wrapper, "mode") == "2":
             outputs = [
-                ct.TensorType(name="logits1", shape=(1, self.context_length, model.config.vocab_size), dtype=np.float16),
-                ct.TensorType(name="logits2", shape=(1, self.context_length, model.config.vocab_size), dtype=np.float16),
+                ct.TensorType(name="logits1", dtype=np.float16),
+                ct.TensorType(name="logits2", dtype=np.float16),
             ]
         else:
-            outputs = [ct.TensorType(name="logits", shape=(1, self.context_length, model.config.vocab_size), dtype=np.float16)]
+            outputs = [ct.TensorType(name="logits", dtype=np.float16)]
 
         mlmodel = ct.convert(
             traced,
@@ -837,8 +829,9 @@ class Gemma3Converter(BaseConverter):
         wrapper.eval()
 
         # Create sample input for tracing
-        sample_input = torch.zeros((1, 512), dtype=torch.int32, device=TEST_DEVICE)
-
+        sample_input = torch.zeros((1, self.context_length), dtype=torch.int32, device=TEST_DEVICE)
+        
+       
         # Trace model
         print("Tracing embeddings model...")
         traced_model = torch.jit.trace(wrapper, sample_input)
@@ -846,7 +839,7 @@ class Gemma3Converter(BaseConverter):
         # Define enumerated input shapes for flexibility
         input_shape = ct.EnumeratedShapes(
             shapes=[
-                [1, 1]
+                [1, 1],
                 [1, self.context_length],
             ],  
             default=[1, self.context_length],  
@@ -860,14 +853,13 @@ class Gemma3Converter(BaseConverter):
             inputs=[
                 ct.TensorType(
                     name="input_ids",
-                    shape=input_shape,  # Use enumerated shapes for flexibility
+                    shape=input_shape, 
                     dtype=np.int32,
                 )
             ],
             outputs=[
                 ct.TensorType(
                     name="hidden_states",
-                    shape=(1, self.context_length, model.config.hidden_size),
                     dtype=np.float16
                 )
             ],

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -367,7 +367,7 @@ class Gemma3Converter(BaseConverter):
             param.requires_grad = False
 
         sample_input = torch.zeros(
-            (1, self.context_length, model.config.hidden_size), dtype=MODEL_DTYPE, device=TEST_DEVICE
+            (1, 1, model.config.hidden_size), dtype=MODEL_DTYPE, device=TEST_DEVICE
         )
         
         # Trace with no_grad context
@@ -465,11 +465,11 @@ class Gemma3Converter(BaseConverter):
         wrapper.eval()
 
         hidden_states = torch.zeros(
-            (1, 512, model.config.hidden_size), dtype=torch.float16, device=TEST_DEVICE
+            (1, 1, model.config.hidden_size), dtype=torch.float16, device=TEST_DEVICE
         )
-        position_ids = torch.zeros((1, 512), dtype=torch.int32, device=TEST_DEVICE)
+        position_ids = torch.zeros((1, ), dtype=torch.int32, device=TEST_DEVICE)
         causal_mask = torch.zeros(
-            (1, 1, 512, self.context_length), dtype=torch.float16, device=TEST_DEVICE
+            (1, 1, 1, self.context_length), dtype=torch.float16, device=TEST_DEVICE
         )
         current_pos = torch.zeros((1,), dtype=torch.int32, device=TEST_DEVICE)
 
@@ -481,16 +481,16 @@ class Gemma3Converter(BaseConverter):
             traced,
             inputs=[
                 ct.TensorType(
-                    name="hidden_states", shape=(1, 512, model.config.hidden_size), dtype=np.float16
+                    name="hidden_states",shape=hidden_states.shape, dtype=np.float16
                 ),
                 ct.TensorType(
-                    name="position_ids", shape=(1, 512), dtype=np.int32
+                    name="position_ids", shape=position_ids.shape, dtype=np.int32
                 ),
                 ct.TensorType(
-                    name="causal_mask", shape=(1, 1, 512, self.context_length), dtype=np.float16
+                    name="causal_mask", shape=causal_mask.shape, dtype=np.float16
                 ),
                 ct.TensorType(
-                    name="current_pos", shape=(1,), dtype=np.int32
+                    name="current_pos", shape=current_pos.shape, dtype=np.int32
                 ),
             ],
             outputs=[ct.TensorType(name="output_hidden_states", dtype=np.float16)],

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -217,26 +217,26 @@ class Gemma3Converter(BaseConverter):
         print("Preparing model inputs for tracing...")
         # Use single token approach for KV cache compatibility
         sample_input_ids = torch.zeros(
-            (1, 1), dtype=torch.int32, device=TEST_DEVICE
-        )  # [1, 1] - single token
+            (1, 512), dtype=torch.int32, device=TEST_DEVICE
+        )  # [1, 512] - single token
         sample_position_ids = torch.zeros(
-            (1,), dtype=torch.int32, device=TEST_DEVICE
-        )  # [1] - single position
+            (1, 512), dtype=torch.int32, device=TEST_DEVICE
+        )  # [1, 512] - single position
         sample_causal_mask = torch.zeros(
-            (1, 1, 1, self.context_length), dtype=torch.float16, device=TEST_DEVICE
-        )  # [1, 1, 1, context_length]
+            (1, 1, 512, self.context_length), dtype=torch.float16, device=TEST_DEVICE
+        )  # [1, 1, 512, context_length]
         sample_current_pos = torch.zeros(
             (1,), dtype=torch.int32, device=TEST_DEVICE
         )  # [1] - current position
-        sample_update_mask = torch.zeros(
-            (1, 1, self.context_length, 1), dtype=torch.float16, device=TEST_DEVICE
-        )  # [1, 1, context_length, 1]
+        #sample_update_mask = torch.zeros(
+            #(1, 1, self.context_length, 1), dtype=torch.float16, device=TEST_DEVICE
+        #)  # [1, 1, context_length, 1]
         print("Sample inputs created (Single Token)")
         print(f"sample_input_ids shape: {sample_input_ids.shape}")
         print(f"sample_position_ids shape: {sample_position_ids.shape}")
         print(f"sample_causal_mask shape: {sample_causal_mask.shape}")
         print(f"sample_current_pos shape: {sample_current_pos.shape}")
-        print(f"sample_update_mask shape: {sample_update_mask.shape}")
+        #print(f"sample_update_mask shape: {sample_update_mask.shape}")
 
         print("Starting torch.jit.trace...")
         traced = torch.jit.trace(
@@ -246,7 +246,7 @@ class Gemma3Converter(BaseConverter):
                 sample_position_ids,
                 sample_causal_mask,
                 sample_current_pos,
-                sample_update_mask,
+                #sample_update_mask,
             ),
         )
         print("torch.jit.trace completed!")
@@ -267,9 +267,9 @@ class Gemma3Converter(BaseConverter):
                 ct.TensorType(
                     name="current_pos", shape=sample_current_pos.shape, dtype=np.int32
                 ),
-                ct.TensorType(
-                    name="update_mask", shape=sample_update_mask.shape, dtype=np.float16
-                ),
+                #ct.TensorType(
+                    #name="update_mask", shape=sample_update_mask.shape, dtype=np.float16
+                #),
             ],
             outputs=[
                 ct.TensorType(name="logits1", dtype=np.float16),
@@ -366,7 +366,7 @@ class Gemma3Converter(BaseConverter):
             param.requires_grad = False
 
         sample_input = torch.zeros(
-            (1, 1, model.config.hidden_size), dtype=MODEL_DTYPE, device=TEST_DEVICE
+            (1, self.context_length, model.config.hidden_size), dtype=MODEL_DTYPE, device=TEST_DEVICE
         )
         
         # Trace with no_grad context
@@ -375,19 +375,27 @@ class Gemma3Converter(BaseConverter):
 
         if getattr(wrapper, "mode") == "16":
             outputs = [
-                ct.TensorType(name=f"logits{i}", dtype=np.float16) for i in range(1, 17)
+                ct.TensorType(
+                    name=f"logits{i}",
+                    shape=(1, self.context_length, model.config.vocab_size),
+                    dtype=np.float16,
+                ) for i in range(1, 17)       
             ]
         elif getattr(wrapper, "mode") == "8":
             outputs = [
-                ct.TensorType(name=f"logits{i}", dtype=np.float16) for i in range(1, 9)
+                ct.TensorType(
+                    name=f"logits{i}",
+                    shape=(1, self.context_length, model.config.vocab_size),
+                    dtype=np.float16,
+                ) for i in range(1, 9)       
             ]
         elif getattr(wrapper, "mode") == "2":
             outputs = [
-                ct.TensorType(name="logits1", dtype=np.float16),
-                ct.TensorType(name="logits2", dtype=np.float16),
+                ct.TensorType(name="logits1", shape=(1, self.context_length, model.config.vocab_size), dtype=np.float16),
+                ct.TensorType(name="logits2", shape=(1, self.context_length, model.config.vocab_size), dtype=np.float16),
             ]
         else:
-            outputs = [ct.TensorType(name="logits", dtype=np.float16)]
+            outputs = [ct.TensorType(name="logits", shape=(1, self.context_length, model.config.vocab_size), dtype=np.float16)]
 
         mlmodel = ct.convert(
             traced,
@@ -465,11 +473,11 @@ class Gemma3Converter(BaseConverter):
         wrapper.eval()
 
         hidden_states = torch.zeros(
-            (1, 1, model.config.hidden_size), dtype=torch.float16, device=TEST_DEVICE
+            (1, 512, model.config.hidden_size), dtype=torch.float16, device=TEST_DEVICE
         )
-        position_ids = torch.zeros((1,), dtype=torch.int32, device=TEST_DEVICE)
+        position_ids = torch.zeros((1, 512), dtype=torch.int32, device=TEST_DEVICE)
         causal_mask = torch.zeros(
-            (1, 1, 1, self.context_length), dtype=torch.float16, device=TEST_DEVICE
+            (1, 1, 512, self.context_length), dtype=torch.float16, device=TEST_DEVICE
         )
         current_pos = torch.zeros((1,), dtype=torch.int32, device=TEST_DEVICE)
 
@@ -481,16 +489,16 @@ class Gemma3Converter(BaseConverter):
             traced,
             inputs=[
                 ct.TensorType(
-                    name="hidden_states", shape=hidden_states.shape, dtype=np.float16
+                    name="hidden_states", shape=(1, 512, model.config.hidden_size), dtype=np.float16
                 ),
                 ct.TensorType(
-                    name="position_ids", shape=position_ids.shape, dtype=np.int32
+                    name="position_ids", shape=(1, 512), dtype=np.int32
                 ),
                 ct.TensorType(
-                    name="causal_mask", shape=causal_mask.shape, dtype=np.float16
+                    name="causal_mask", shape=(1, 1, 512, self.context_length), dtype=np.float16
                 ),
                 ct.TensorType(
-                    name="current_pos", shape=current_pos.shape, dtype=np.int32
+                    name="current_pos", shape=(1,), dtype=np.int32
                 ),
             ],
             outputs=[ct.TensorType(name="output_hidden_states", dtype=np.float16)],
@@ -835,13 +843,13 @@ class Gemma3Converter(BaseConverter):
         print("Tracing embeddings model...")
         traced_model = torch.jit.trace(wrapper, sample_input)
 
-        # Define flexible input shapes for both single token and batch processing
+        # Define enumerated input shapes for flexibility
         input_shape = ct.EnumeratedShapes(
             shapes=[
-                [1, 1],
-                [1, self.batch_size],
-            ],  # Support single token and batch_size tokens
-            default=[1, 1],  # Use single token as default
+                
+                [1, self.context_length],
+            ],  
+            default=[1, self.context_length],  
         )
 
         print(f"Converting embeddings model with input shape: {input_shape}")
@@ -856,7 +864,13 @@ class Gemma3Converter(BaseConverter):
                     dtype=np.int32,
                 )
             ],
-            outputs=[ct.TensorType(name="hidden_states", dtype=np.float16)],
+            outputs=[
+                ct.TensorType(
+                    name="hidden_states",
+                    shape=(1, self.context_length, model.config.hidden_size),
+                    dtype=np.float16
+                )
+            ],
             compute_precision=ct.precision.FLOAT16,
             compute_units=ct.ComputeUnit.CPU_AND_NE,
             minimum_deployment_target=ct.target.iOS18,

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -683,7 +683,8 @@ class Gemma3Converter(BaseConverter):
             mlmodel = self.converted_model
         
         return mlmodel
-    
+        
+    # don't use this
     def convert_prefill(self, model: Gemma3ForCausalLM) -> ct.models.MLModel:
         """Convert Gemma3 model to CoreML format for prefill mode.
 
@@ -837,14 +838,14 @@ class Gemma3Converter(BaseConverter):
         traced_model = torch.jit.trace(wrapper, sample_input)
 
         # Define enumerated input shapes for flexibility
-        input_shape = ct.EnumeratedShapes(
-            shapes=[
-                [1, 1],
-                [1, self.context_length],
-                [1,	64],
-            ],  
-            default=[1, self.context_length],  
-        )
+        #input_shape = ct.EnumeratedShapes(
+            #shapes=[
+                #[1, 1],
+                #[1, self.context_length],
+                #[1, 64],
+            #],  
+            #default=[1, self.context_length],  
+        #)
 
         print(f"Converting embeddings model with input shape: {input_shape}")
 
@@ -854,7 +855,7 @@ class Gemma3Converter(BaseConverter):
             inputs=[
                 ct.TensorType(
                     name="input_ids",
-                    shape=input_shape, 
+                    shape=sample_input.shape, 
                     dtype=np.int32,
                 )
             ],

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -841,6 +841,7 @@ class Gemma3Converter(BaseConverter):
             shapes=[
                 [1, 1],
                 [1, self.context_length],
+                [1,	64],
             ],  
             default=[1, self.context_length],  
         )

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -1,8 +1,4 @@
-"""Converter for Gemma 3 models.
-
-This module provides a lightweight converter that mirrors the
-:class:`QwenConverter` behaviour for Gemma3 models without inheriting from
-it. Only the pieces required for the unit tests are implemented."""
+"""Full converter for Gemma 3 models."""
 
 from __future__ import annotations
 

--- a/anemll/ane_converter/gemma3_converter.py
+++ b/anemll/ane_converter/gemma3_converter.py
@@ -467,7 +467,7 @@ class Gemma3Converter(BaseConverter):
         hidden_states = torch.zeros(
             (1, 1, model.config.hidden_size), dtype=torch.float16, device=TEST_DEVICE
         )
-        position_ids = torch.zeros((1, ), dtype=torch.int32, device=TEST_DEVICE)
+        position_ids = torch.zeros((1, 1), dtype=torch.int32, device=TEST_DEVICE)
         causal_mask = torch.zeros(
             (1, 1, 1, self.context_length), dtype=torch.float16, device=TEST_DEVICE
         )

--- a/anemll/models/gemma3_model.py
+++ b/anemll/models/gemma3_model.py
@@ -149,14 +149,27 @@ class Gemma3MLP(nn.Module):
         self.down_proj = nn.Conv2d(self.intermediate_size, self.hidden_size, kernel_size=1, bias=False, dtype=MODEL_DTYPE)
         self.act_fn = ACT2FN[config.hidden_act]
 
-    def forward(self, x):
+    #def forward(self, x):
         
-        x = x.to(MODEL_DTYPE).permute(0, 2, 1).unsqueeze(2)
+        #x = x.to(MODEL_DTYPE).permute(0, 2, 1).unsqueeze(2)
         
-        down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+        #down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
         
        
-        return down_proj.squeeze(2).permute(0, 2, 1)
+        #return down_proj.squeeze(2).permute(0, 2, 1)
+
+    def forward(self, x):
+        # Use identical step-by-step computation to LlamaMLP to prevent numerical explosion
+        x = x.to(MODEL_DTYPE).permute(0, 2, 1).unsqueeze(2)  # Ensure proper dtype and shape
+        
+        # Step-by-step computation for numerical stability (like LlamaMLP)
+        a = self.gate_proj(x)      # gate projection
+        b = self.up_proj(x)        # up projection
+        c = self.act_fn(a)         # activation on gate
+        d = c * b                  # multiply gate * up
+        e = self.down_proj(d)      # down projection
+        
+        return e.squeeze(2).permute(0, 2, 1)  # Final output shape: [bsz, seq_len, hidden_size]
     
 class Gemma3RMSNorm(nn.Module):
     """Manual RMSNorm implementation with explicit dtype handling for JIT compatibility."""
@@ -450,6 +463,8 @@ class Gemma3TextModel(nn.Module):
         config.rope_theta = config.rope_local_base_freq
         config.rope_scaling = {"rope_type": "default"}
         self.rotary_emb_local = Gemma3RotaryEmbedding(config=config)
+        for i in range(self.config.num_hidden_layers):
+            self.register_buffer(f"kv_cache_{i}", None)
 
         # Initialize weights and apply final processing
         # self.post_init() # This was causing the error and is not needed
@@ -493,6 +508,7 @@ class Gemma3TextModel(nn.Module):
             print("Missing keys in model:", missing)
             print("Unexpected keys in model:", unexpected)
         return not missing and not unexpected
+
 
     def forward(
         self,
@@ -674,7 +690,16 @@ class Gemma3ForCausalLM(nn.Module):
         
         self.model = Gemma3TextModel(config)
         # Set the disable_kv_cache flag on the model
-        self.model.disable_kv_cache = self.disable_kv_cache
+        for i in range(self.config.num_hidden_layers):
+            self.model.register_buffer(f"kv_cache_{i}", None)
+        head_dim = config.hidden_size // config.num_attention_heads
+        cache_size = (
+            2 * config.num_hidden_layers,
+            config.num_key_value_heads,
+            config.state_length,
+            head_dim
+        )
+        self.register_buffer("kv_cache_0", torch.zeros(cache_size, dtype=MODEL_DTYPE, device=TEST_DEVICE))
         
         # Initialize lm_head as Conv2d for ANE optimization following llama_model.py pattern
         if ENABLE_CONV2D:

--- a/anemll/models/gemma3_model.py
+++ b/anemll/models/gemma3_model.py
@@ -12,7 +12,7 @@ from linecache import cache
 import os
 import json
 import math
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Tuple
 import copy
 
 import safetensors.torch
@@ -44,7 +44,7 @@ CONTEXT_LENGTH = 1024
 # Cache configuration constants (following llama_model.py pattern)
 FORCE_UNIFIED_CACHE = True  # Force using a single unified KV cache
 ENABLE_UNIFIED_CACHE = True  # Enable unified KV cache by default
-STATE_LENGTH = 512   # KV cache state length
+STATE_LENGTH = CONTEXT_LENGTH  # KV cache state length
 DISABLE_KV_CACHE = False  # Disable KV cache for simple testing
 
 # LM head configuration constants (following llama_model.py pattern)
@@ -745,6 +745,9 @@ class Gemma3ForCausalLM(nn.Module):
         causal_mask: torch.Tensor,
         current_pos: torch.LongTensor,
         IN_PREFILL: bool = False,
+        past_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = None,
+        use_cache: bool = True
+    
     ) -> torch.Tensor:
         assert len(input_ids.shape) == 2, "input_ids must be 2D"
         if not ENABLE_COREML:
@@ -763,6 +766,7 @@ class Gemma3ForCausalLM(nn.Module):
                 causal_mask,
                 position_ids,
                 current_pos,
+                past_key_values=past_key_values,
                 IN_PREFILL=IN_PREFILL,
             )
         else:
@@ -772,6 +776,7 @@ class Gemma3ForCausalLM(nn.Module):
                 causal_mask,
                 position_ids,
                 current_pos,
+                past_key_values=past_key_values,
                 IN_PREFILL=IN_PREFILL,
             )
         
@@ -855,8 +860,8 @@ class Gemma3ForCausalLM(nn.Module):
             # Use linear head (fallback)
             logits = self.lm_head(hidden_states.permute(0, 2, 1).unsqueeze(2))
             logits = logits.squeeze(2).permute(0, 2, 1)
-        
-        return logits
+
+        return logits,past_key_values,hidden_states
 
     def prefill_kv_cache(self, input_ids, position_ids, start_pos, causal_mask):
         """

--- a/anemll/models/gemma3_model.py
+++ b/anemll/models/gemma3_model.py
@@ -1,0 +1,882 @@
+"""Gemma 3 model implementation for ANEMLL.
+
+This module provides a lightweight implementation of the Gemma 3 architecture
+adapted to the Apple Neural Engine restrictions.  All dense layers are expressed
+as ``nn.Conv2d`` with ``kernel_size=1`` and weights are loaded from Hugging Face
+checkpoints with the correct reshaping.  Only the pieces required for the unit
+ tests are implemented.
+"""
+
+from __future__ import annotations
+import os
+import json
+import math
+from typing import Dict
+import copy
+
+import safetensors.torch
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+# ---------------------------------------------------------------------------
+# Gemma 3 model implementation adapted from qwen_model.py
+# ---------------------------------------------------------------------------
+
+def gelu_pytorch_tanh(x):
+    """
+    A fast GELU implementation approximation from the original Gemma implementation.
+    """
+    return 0.5 * x * (1.0 + torch.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * torch.pow(x, 3.0))))
+
+ACT2FN = {
+    "gelu_pytorch_tanh": gelu_pytorch_tanh,
+    "gelu": F.gelu,
+    "silu": F.silu,
+}
+
+MODEL_DTYPE = torch.float16
+TEST_DEVICE = "cpu"
+CONTEXT_LENGTH = 1024
+
+# Cache configuration constants (following llama_model.py pattern)
+FORCE_UNIFIED_CACHE = True  # Force using a single unified KV cache
+ENABLE_UNIFIED_CACHE = True  # Enable unified KV cache by default
+STATE_LENGTH = 512   # KV cache state length
+DISABLE_KV_CACHE = False  # Disable KV cache for simple testing
+
+# LM head configuration constants (following llama_model.py pattern)
+ENABLE_CONV2D = bool(1)      # Use Conv2d for LM head
+ENABLE_VACAB_SPLIT = bool(1)  # Split vocab into 2 parts
+ENABLE_VACAB_SPLIT8 = bool(0)  # Split vocab into 8 parts
+ENABLE_VACAB_SPLIT16 = bool(1)  # Split vocab into 16 parts
+ENABLE_LOGITS2 = bool(1)    # Return separate logits arrays for CoreML
+ENABLE_COREML = bool(0)     # CoreML-specific returns
+
+
+class Gemma3Config:
+    def __init__(self, **kwargs):
+        self.architectures = kwargs.get("architectures", ["Gemma3ForCausalLM"])
+        self.attention_bias = kwargs.get("attention_bias", False)
+        self.attention_dropout = kwargs.get("attention_dropout", 0.0)
+        self.bos_token_id = kwargs.get("bos_token_id", 2)
+        self.eos_token_id = kwargs.get("eos_token_id", 1)
+        self.hidden_act = kwargs.get("hidden_act", "gelu_pytorch_tanh")
+        self.hidden_size = kwargs.get("hidden_size", 2304)
+        self.initializer_range = kwargs.get("initializer_range", 0.02)
+        self.intermediate_size = kwargs.get("intermediate_size", 9216)
+        self.max_position_embeddings = kwargs.get("max_position_embeddings", 131072)
+        self.model_type = kwargs.get("model_type", "gemma3")
+        self.num_attention_heads = kwargs.get("num_attention_heads", 8)
+        self.num_hidden_layers = kwargs.get("num_hidden_layers", 26)
+        self.num_key_value_heads = kwargs.get("num_key_value_heads", 4)
+        self.head_dim = kwargs.get(
+            "head_dim",
+            256
+        )
+        self.rms_norm_eps = kwargs.get("rms_norm_eps", 1e-06)
+        self.rope_scaling = kwargs.get("rope_scaling", None)
+        if self.rope_scaling:
+            self.rope_scaling["rope_type"] = self.rope_scaling.get("rope_type", "gemma3")
+        self.rope_theta = kwargs.get("rope_theta", 1000000.0)
+        self.tie_word_embeddings = kwargs.get("tie_word_embeddings", True)
+        self.torch_required = kwargs.get("torch_dtype", "bfloat16")
+        self.transformers_version = kwargs.get("transformers_version", "4.40.0.dev0")
+        self.use_cache = kwargs.get("use_cache", True)
+        self.vocab_size = kwargs.get("vocab_size", 262208)
+        self.context_length = kwargs.get("context_length", CONTEXT_LENGTH)
+        self.state_length = kwargs.get("state_length", STATE_LENGTH)
+        self.pad_token_id = kwargs.get("pad_token_id",0)
+        self.query_pre_attn_scalar = kwargs.get("query_pre_attn_scalar",256)
+        self.sliding_window = kwargs.get("sliding_window",4096)
+        self.final_logit_softcapping = kwargs.get("final_logit_softcapping",None)
+        self.attn_logit_softcapping = kwargs.get("attn_logit_softcapping",None)
+        self.cache_implementation = kwargs.get("cache_implementation","hybrid")
+        self.rope_local_base_freq = kwargs.get("rope_local_base_freq",10000.0)
+        self.sliding_window_pattern = kwargs.get("sliding_window_pattern",6)
+        self.layer_types: list[str] = kwargs.get(
+            "layer_types",
+            ["attention"] * self.num_hidden_layers  # Default to standard attention if not provided
+        )
+
+    @classmethod
+    def from_json(cls, json_file):
+        with open(json_file, "r") as f:
+            config_dict = json.load(f)
+        return cls(**config_dict)
+
+
+def get_kv_cache_idx(layer_idx, num_layers, num_groups=1):
+    layers_per_group = num_layers // num_groups
+    group_idx = layer_idx // layers_per_group
+    layer_in_group_idx = layer_idx % layers_per_group
+    return group_idx, layer_in_group_idx, layers_per_group
+
+
+# -----------------------------------------------------------------------------
+# Gemma3 building blocks
+# -----------------------------------------------------------------------------
+
+def _rope_init_default(config, device=None):
+    """
+    Default RoPE initialization function.
+    """
+    dim = config.head_dim
+    base = config.rope_theta
+    inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64).float().to(device) / dim))
+    attention_scaling = 1.0
+    return inv_freq, attention_scaling
+
+ROPE_INIT_FUNCTIONS = {
+    "default": _rope_init_default,
+    "gemma3": _rope_init_default,
+}
+
+
+class Gemma3MLP(nn.Module):
+    def __init__(self, config: Gemma3Config):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_proj = nn.Conv2d(self.hidden_size, self.intermediate_size, 1, bias=False)
+        self.up_proj = nn.Conv2d(self.hidden_size, self.intermediate_size, 1, bias=False)
+        self.down_proj = nn.Conv2d(self.intermediate_size, self.hidden_size, 1, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x):
+        # Reshape for Conv2d: [batch, seq_len, hidden_size] -> [batch, hidden_size, seq_len, 1]
+        x = x.transpose(1, 2).unsqueeze(-1)
+        down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+        # Reshape back: [batch, hidden_size, seq_len, 1] -> [batch, seq_len, hidden_size]
+        return down_proj.squeeze(-1).transpose(1, 2)
+
+class Gemma3RMSNorm(nn.Module):
+    """Manual RMSNorm implementation with explicit dtype handling for JIT compatibility."""
+
+    def __init__(self, hidden_size, eps=1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        # Cast to float32 for high-precision calculation
+        hidden_states = hidden_states.to(torch.float32)
+        
+        # Manual RMSNorm calculation in float32
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        
+        # Apply weight (also in float32) and cast back to original dtype
+        return (hidden_states * self.weight.to(torch.float32)).to(input_dtype)
+
+
+class Gemma3HeadNorm(nn.Module):
+    """Manual RMSNorm implementation with explicit dtype handling for JIT compatibility."""
+
+    def __init__(self, hidden_size, eps=1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        # Cast to float32 for high-precision calculation
+        hidden_states = hidden_states.to(torch.float32)
+        
+        # Manual RMSNorm calculation in float32
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        
+        # Apply weight (also in float32) and cast back to original dtype
+        return (hidden_states * self.weight.to(torch.float32)).to(input_dtype)
+
+
+class Gemma3RotaryEmbedding(nn.Module):
+    """Simple rotary positional embedding."""
+
+    inv_freq: torch.Tensor  # fix linting for `register_buffer`
+
+    def __init__(self, config: Gemma3Config, device=None):
+        super().__init__()
+        # BC: "rope_type" was originally "type"
+        if hasattr(config, "rope_scaling") and isinstance(config.rope_scaling, dict):
+            self.rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type"))
+        else:
+            self.rope_type = "default"
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+
+        self.config = config
+        self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+
+        inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.original_inv_freq = self.inv_freq
+
+    @torch.no_grad()
+    #@dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
+    def forward(self, x, position_ids):
+        # Ensure position_ids is 2D for consistent processing
+        if position_ids.dim() == 1:
+            position_ids = position_ids.unsqueeze(0)
+
+        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        position_ids_expanded = position_ids[:, None, :].float()
+
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with torch.autocast(device_type=device_type, enabled=False):  # Force float32
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * self.attention_scaling
+            sin = emb.sin() * self.attention_scaling
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    """Applies Rotary Position Embedding to the query and key tensors.
+
+    Args:
+        q (`torch.Tensor`): The query tensor.
+        k (`torch.Tensor`): The key tensor.
+        cos (`torch.Tensor`): The cosine part of the rotary embedding.
+        sin (`torch.Tensor`): The sine part of the rotary embedding.
+        position_ids (`torch.Tensor`, *optional*):
+            Deprecated and unused.
+        unsqueeze_dim (`int`, *optional*, defaults to 1):
+            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
+            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
+            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
+            k have the shape [batch_size, heads, seq_len, head_dim], then set unsqueeze_dim=1 makes
+            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
+            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
+    Returns:
+        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
+    """
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """
+    This is the equivalent of torch.repeat_interleave(x, dim=1, repeats=n_rep). The hidden states go from (batch,
+    num_key_value_heads, seqlen, head_dim) to (batch, num_attention_heads, seqlen, head_dim)
+    """
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+def eager_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+    dropout: float = 0.0,
+    scaling: Optional[float] = None,
+    softcap: Optional[float] = None,
+    **kwargs,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if scaling is None:
+        scaling = module.head_dim**-0.5
+
+    key_states = repeat_kv(key, module.num_key_value_groups)
+    value_states = repeat_kv(value, module.num_key_value_groups)
+
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
+
+    if softcap is not None:
+        attn_weights = attn_weights / softcap
+        attn_weights = torch.tanh(attn_weights)
+        attn_weights = attn_weights * softcap
+    if attention_mask is not None:  # no matter the length, we just slice it
+        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+        attn_weights = attn_weights + causal_mask
+
+    # upcast attention to fp32
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
+    attn_output = torch.matmul(attn_weights, value_states)
+    attn_output = attn_output.transpose(1, 2).contiguous()
+    return attn_output, attn_weights
+
+
+
+class Gemma3DecoderLayer(nn.Module):
+    def __init__(self, config: Gemma3Config, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.layer_idx = layer_idx
+        self.attention_type = config.layer_types#[layer_idx]
+        # pass layer_idx so Gemma3Attention can pick per-layer settings
+        self.self_attn = Gemma3Attention(config=config, layer_idx=layer_idx)
+        self.mlp = Gemma3MLP(config)
+        self.input_layernorm = Gemma3RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Gemma3RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+        self.pre_feedforward_layernorm = Gemma3RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+        self.post_feedforward_layernorm = Gemma3RMSNorm(self.hidden_size, eps=config.rms_norm_eps)
+
+   
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: torch.Tensor,
+        attention_mask:torch.Tensor = None,
+        position_ids: torch.LongTensor = None,
+        past_key_values: [Cache] = None, # type: ignore
+        output_attentions: [bool] = False,# type: ignore
+        use_cache: [bool] = False, # type: ignore
+        cache_position: [torch.LongTensor] = None, # type: ignore
+        **kwargs,
+    ) -> tuple[torch.FloatTensor, Optional[tuple[torch.FloatTensor, torch.FloatTensor]]]:
+        # This is the standard Transformer block structure.
+        
+        # 1. Self-Attention block
+        residual = hidden_states
+        normed_hidden_states = self.input_layernorm(hidden_states)
+        attn_outputs, self_attn_weights = self.self_attn(
+            hidden_states=normed_hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        hidden_states = residual + attn_outputs
+
+        # 2. MLP (Feed-Forward) block
+        residual = hidden_states
+        normed_hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(normed_hidden_states)
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states,)
+
+        if output_attentions:
+            outputs += (self_attn_weights,)
+
+        return outputs
+        
+class Gemma3TextScaledWordEmbedding(nn.Embedding):
+    """
+    This module overrides nn.Embeddings' forward by multiplying with embeddings scale.
+    """
+
+    def __init__(self, num_embeddings: int, embedding_dim: int, padding_idx: int, embed_scale: float = 1.0):
+        super().__init__(num_embeddings, embedding_dim, padding_idx)
+        self.register_buffer("embed_scale", torch.tensor(embed_scale), persistent=False)
+
+    def forward(self, input_ids: torch.Tensor):
+        return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)
+
+class Gemma3TextModel(nn.Module):
+    config: Gemma3Config
+
+    def __init__(self, config: Gemma3Config):
+        super().__init__()
+        self.config = config
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        # Gemma3 downcasts the below to bfloat16, causing sqrt(3072)=55.4256 to become 55.5. See https://github.com/huggingface/transformers/pull/29402
+        self.embed_tokens = Gemma3TextScaledWordEmbedding(
+            config.vocab_size, config.hidden_size, self.padding_idx, embed_scale=self.config.hidden_size**0.5
+        )
+        # create ModuleList with per-layer indices so Gemma3DecoderLayer gets layer_idx
+        self.layers = nn.ModuleList([Gemma3DecoderLayer(config, i) for i in range(self.config.num_hidden_layers)])
+        self.norm = Gemma3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Gemma3RotaryEmbedding(config=config)
+        self.gradient_checkpointing = False
+
+        # TODO: raushan fix this after RoPE refactor. For now we hack it by reassigning thetas
+        # when we want to create a local RoPE layer. Config defaults should hold values for global RoPE
+        config = copy.deepcopy(config)
+        config.rope_theta = config.rope_local_base_freq
+        config.rope_scaling = {"rope_type": "default"}
+        self.rotary_emb_local = Gemma3RotaryEmbedding(config=config)
+
+        # Initialize weights and apply final processing
+        # self.post_init() # This was causing the error and is not needed
+
+    def load_pretrained_weights(self, model_path: str) -> bool:
+        if not os.path.isdir(model_path):
+            raise FileNotFoundError(model_path)
+        state_dict: Dict[str, torch.Tensor] = {}
+        for file in os.listdir(model_path):
+            if file.endswith(".safetensors"):
+                state_dict.update(
+                    safetensors.torch.load_file(os.path.join(model_path, file))
+                )
+
+        conv_state = {}
+        for k, v in state_dict.items():
+            new_k = k.replace("model.", "") if k.startswith("model.") else k
+            if "lm_head.weight" in new_k:
+                continue
+            if any(
+                proj in new_k
+                for proj in [
+                    "q_proj.weight",
+                    "k_proj.weight",
+                    "v_proj.weight",
+                    "o_proj.weight",
+                    "gate_proj.weight",
+                    "up_proj.weight",
+                    "down_proj.weight",
+                ]
+            ):
+                # Reshape linear weights to Conv2d weights
+                conv_state[new_k] = v.view(v.shape[0], v.shape[1], 1, 1)
+            else:
+                conv_state[new_k] = v
+
+        missing, unexpected = self.load_state_dict(conv_state, strict=False)
+        # Filter out expected missing keys
+        missing = [m for m in missing if "rotary_emb.inv_freq" not in m]
+        if missing or unexpected:
+            print("Missing keys in model:", missing)
+            print("Unexpected keys in model:", unexpected)
+        return not missing and not unexpected
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        causal_mask: torch.Tensor,
+        position_ids: torch.LongTensor,
+        current_pos: torch.LongTensor,
+        IN_PREFILL: bool = False,
+    ) -> torch.Tensor:
+        hidden_states = self.embed_tokens(input_ids)
+
+        # create position embeddings to be shared across the decoder layers
+        position_embeddings_global = self.rotary_emb(hidden_states, position_ids)
+        position_embeddings_local = self.rotary_emb_local(hidden_states, position_ids)
+
+        for decoder_layer in self.layers:
+            # Determine which position embeddings to use for the layer
+            if decoder_layer.self_attn.is_sliding:
+                position_embeddings = position_embeddings_local
+            else:
+                position_embeddings = position_embeddings_global
+
+            # The forward pass of Gemma3DecoderLayer expects a single position_embeddings argument
+            layer_outputs = decoder_layer(
+                hidden_states,
+                position_embeddings=position_embeddings,
+                attention_mask=causal_mask,
+                position_ids=position_ids,
+            )
+            hidden_states = layer_outputs[0]
+
+        hidden_states = self.norm(hidden_states)
+        return hidden_states
+
+
+class Gemma3Attention(nn.Module):
+    """Multi-headed attention from 'Attention Is All You Need' paper"""
+
+    def __init__(self, config: Gemma3Config, layer_idx: int):
+        super().__init__()
+        self.is_sliding = config.layer_types[layer_idx] == "sliding_attention"
+        self.config = config
+        self.layer_idx = layer_idx
+        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
+        self.scaling = config.query_pre_attn_scalar**-0.5
+        self.attention_dropout = self.config.attention_dropout
+        self.is_causal = True
+
+        self.q_proj = nn.Conv2d(
+            config.hidden_size, config.num_attention_heads * self.head_dim, 1, bias=config.attention_bias
+        )
+        self.k_proj = nn.Conv2d(
+            config.hidden_size, config.num_key_value_heads * self.head_dim, 1, bias=config.attention_bias
+        )
+        self.v_proj = nn.Conv2d(
+            config.hidden_size, config.num_key_value_heads * self.head_dim, 1, bias=config.attention_bias
+        )
+        self.o_proj = nn.Conv2d(
+            config.num_attention_heads * self.head_dim, config.hidden_size, 1, bias=config.attention_bias
+        )
+        self.attn_logit_softcapping = self.config.attn_logit_softcapping
+        self.sliding_window = config.sliding_window if self.is_sliding else None
+
+        self.q_norm = Gemma3RMSNorm(hidden_size=config.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = Gemma3RMSNorm(hidden_size=config.head_dim, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: torch.Tensor,
+        attention_mask: Optional[torch.Tensor],
+        # Remove unused arguments from transformers-style forward
+        # past_key_values: Optional[Cache] = None,
+        # cache_position: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        bsz, q_len, _ = hidden_states.size()
+
+        # Reshape for Conv2d: [batch, seq_len, hidden_size] -> [batch, hidden_size, seq_len, 1]
+        hidden_states_conv = hidden_states.transpose(1, 2).unsqueeze(-1)
+
+        query_states = self.q_proj(hidden_states_conv).squeeze(-1).transpose(1, 2)
+        key_states = self.k_proj(hidden_states_conv).squeeze(-1).transpose(1, 2)
+        value_states = self.v_proj(hidden_states_conv).squeeze(-1).transpose(1, 2)
+
+        query_states = query_states.view(bsz, q_len, self.config.num_attention_heads, self.head_dim).transpose(1, 2)
+        key_states = key_states.view(bsz, q_len, self.config.num_key_value_heads, self.head_dim).transpose(1, 2)
+        value_states = value_states.view(bsz, q_len, self.config.num_key_value_heads, self.head_dim).transpose(1, 2)
+
+        query_states = self.q_norm(query_states)
+        key_states = self.k_norm(key_states)
+
+        # Ensure the output of norm layers is in the correct dtype before RoPE
+        query_states = query_states.to(MODEL_DTYPE)
+        key_states = key_states.to(MODEL_DTYPE)
+
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        # KV Cache is handled by the converter/runner, not in the model forward pass for this implementation
+        # if past_key_values is not None:
+        #     cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+        #     key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
+
+        # Repeat KV heads if using GQA
+        key_states = repeat_kv(key_states, self.num_key_value_groups)
+        value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+        attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * self.scaling
+
+        if self.attn_logit_softcapping is not None:
+            attn_weights = attn_weights / self.attn_logit_softcapping
+            attn_weights = torch.tanh(attn_weights)
+            attn_weights = attn_weights * self.attn_logit_softcapping
+
+        if attention_mask is not None:
+            if attention_mask.size() != attn_weights.size():
+                attention_mask = attention_mask[:, :, :q_len, :key_states.shape[-2]]
+            attn_weights = attn_weights + attention_mask
+
+        # upcast attention to fp32
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+        attn_weights = nn.functional.dropout(attn_weights, p=self.attention_dropout, training=False)
+        attn_output = torch.matmul(attn_weights, value_states)
+
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.reshape(bsz, q_len, self.config.hidden_size)
+
+        # Reshape for o_proj Conv2d
+        attn_output_conv = attn_output.transpose(1, 2).unsqueeze(-1)
+        attn_output = self.o_proj(attn_output_conv).squeeze(-1).transpose(1, 2)
+
+        return attn_output, attn_weights
+
+
+class Gemma3ForCausalLM(nn.Module):
+    config_class = Gemma3Config
+
+    def __init__(self, config: Gemma3Config, enable_coreml=False, disable_kv_cache=False, **kwargs) -> None:
+        super().__init__()
+        self.config = config
+        self.enable_coreml = enable_coreml
+        self.disable_kv_cache = disable_kv_cache or DISABLE_KV_CACHE
+        
+        # Update global ENABLE_COREML flag when instance is created with enable_coreml=True
+        if enable_coreml:
+            global ENABLE_COREML
+            ENABLE_COREML = True
+            print(f"Set global ENABLE_COREML = {ENABLE_COREML} for CoreML conversion")
+        
+        self.model = Gemma3TextModel(config)
+        # Set the disable_kv_cache flag on the model
+        self.model.disable_kv_cache = self.disable_kv_cache
+        
+        # Initialize lm_head as Conv2d for ANE optimization following llama_model.py pattern
+        if ENABLE_CONV2D:
+            if ENABLE_VACAB_SPLIT16:
+                vocab_split = config.vocab_size // 16
+                vocab_remainder = config.vocab_size % 16
+                # Create 16 heads, with the first ones handling any remainder
+                for i in range(16):
+                    split_size = vocab_split + (1 if i < vocab_remainder else 0)
+                    setattr(self, f"lm_head16_{i+1}",
+                           nn.Conv2d(config.hidden_size, split_size, 1, bias=False, dtype=MODEL_DTYPE).to(TEST_DEVICE))
+                if not hasattr(Gemma3ForCausalLM, '_lm_head_printed'):
+                    print("Created lm_head16_1 through lm_head16_16")
+                    Gemma3ForCausalLM._lm_head_printed = True
+            elif ENABLE_VACAB_SPLIT8:
+                vocab_split = config.vocab_size // 8
+                vocab_remainder = config.vocab_size % 8
+                # Create 8 heads, with the last one handling any remainder
+                for i in range(8):
+                    split_size = vocab_split + (1 if i < vocab_remainder else 0)
+                    setattr(self, f"lm_head8_{i+1}",
+                           nn.Conv2d(config.hidden_size, split_size, 1, bias=False, dtype=MODEL_DTYPE).to(TEST_DEVICE))
+                print("Created lm_head8_1 through lm_head8_8")
+            elif ENABLE_VACAB_SPLIT:
+                self.lm_head2_1 = nn.Conv2d(config.hidden_size, config.vocab_size//2, 1, bias=False, dtype=MODEL_DTYPE).to(TEST_DEVICE)
+                self.lm_head2_2 = nn.Conv2d(config.hidden_size, config.vocab_size//2, 1, bias=False, dtype=MODEL_DTYPE).to(TEST_DEVICE)
+                print("Created lm_head2_1 and lm_head2_2")
+            else:
+                self.lm_head1 = nn.Conv2d(config.hidden_size, config.vocab_size, 1, bias=False, dtype=MODEL_DTYPE).to(TEST_DEVICE)
+                print("Created lm_head1")
+        else:
+            # Use linear head
+            self.lm_head = nn.Conv2d(
+                config.hidden_size, config.vocab_size, 1, bias=False, dtype=MODEL_DTYPE
+            ).to(TEST_DEVICE)
+            print("Created linear lm_head")
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        update_mask: torch.Tensor,
+        position_ids: torch.LongTensor,
+        causal_mask: torch.Tensor,
+        current_pos: torch.LongTensor,
+        IN_PREFILL: bool = False,
+    ) -> torch.Tensor:
+        assert len(input_ids.shape) == 2, "input_ids must be 2D"
+        if not ENABLE_COREML:
+            if not IN_PREFILL:
+                assert position_ids.ndim in (1, 2), "position_ids must be 1D or 2D"
+            else:
+                assert (
+                    position_ids.shape[-1] == input_ids.shape[-1]
+                ), "position_ids length must match input_ids in prefill"
+
+        if self.disable_kv_cache:
+            # Use the same forward path as KV cache, but without cache operations
+            # This ensures identical attention computation
+            hidden_states = self.model(
+                input_ids,
+                causal_mask,
+                position_ids,
+                current_pos,
+                IN_PREFILL=IN_PREFILL,
+            )
+        else:
+            # Standard KV cache path
+            hidden_states = self.model(
+                input_ids,
+                causal_mask,
+                position_ids,
+                current_pos,
+                IN_PREFILL=IN_PREFILL,
+            )
+        
+        # Extract hidden states at current position right before LM head
+        if not IN_PREFILL and current_pos is not None:
+            # For single token generation, extract the last (and only) position from hidden_states
+            # hidden_states has shape [batch, 1, hidden_size] for single token generation
+            seq_len = hidden_states.shape[1]
+            if seq_len == 1:
+                # Single token case - use position 0 (the only position available)
+                pos_tensor = torch.tensor([0], device=hidden_states.device, dtype=torch.long)
+            else:
+                # Multi-token case - use the actual current_pos (for compatibility)
+                if isinstance(current_pos, torch.Tensor):
+                    pos_tensor = current_pos if current_pos.dim() > 0 else current_pos.unsqueeze(0)
+                else:
+                    pos_tensor = torch.tensor([current_pos], device=hidden_states.device, dtype=torch.long)
+            
+            # Use index_select for position extraction
+            hidden_states = torch.index_select(hidden_states, dim=1, index=pos_tensor)  # [batch, 1, hidden_size]
+        
+        # Project to vocabulary using appropriate head
+        if ENABLE_CONV2D:
+            # Reshape for Conv2d and ensure float16
+            hidden_states = hidden_states.permute(0, 2, 1).unsqueeze(2).to(MODEL_DTYPE)
+            
+            if ENABLE_VACAB_SPLIT16:
+                # Use 16-way split head
+                logits1 = self.lm_head16_1(hidden_states).squeeze(2).transpose(1, 2)
+                logits2 = self.lm_head16_2(hidden_states).squeeze(2).transpose(1, 2)
+                logits3 = self.lm_head16_3(hidden_states).squeeze(2).transpose(1, 2)
+                logits4 = self.lm_head16_4(hidden_states).squeeze(2).transpose(1, 2)
+                logits5 = self.lm_head16_5(hidden_states).squeeze(2).transpose(1, 2)
+                logits6 = self.lm_head16_6(hidden_states).squeeze(2).transpose(1, 2)
+                logits7 = self.lm_head16_7(hidden_states).squeeze(2).transpose(1, 2)
+                logits8 = self.lm_head16_8(hidden_states).squeeze(2).transpose(1, 2)
+                logits9 = self.lm_head16_9(hidden_states).squeeze(2).transpose(1, 2)
+                logits10 = self.lm_head16_10(hidden_states).squeeze(2).transpose(1, 2)
+                logits11 = self.lm_head16_11(hidden_states).squeeze(2).transpose(1, 2)
+                logits12 = self.lm_head16_12(hidden_states).squeeze(2).transpose(1, 2)
+                logits13 = self.lm_head16_13(hidden_states).squeeze(2).transpose(1, 2)
+                logits14 = self.lm_head16_14(hidden_states).squeeze(2).transpose(1, 2)
+                logits15 = self.lm_head16_15(hidden_states).squeeze(2).transpose(1, 2)
+                logits16 = self.lm_head16_16(hidden_states).squeeze(2).transpose(1, 2)
+                
+                if self.enable_coreml and ENABLE_LOGITS2:
+                    return logits1, logits2, logits3, logits4, logits5, logits6, logits7, logits8, logits9, logits10, logits11, logits12, logits13, logits14, logits15, logits16
+                else:
+                    logits = torch.cat([logits1, logits2, logits3, logits4, logits5, logits6, logits7, logits8, logits9, logits10, logits11, logits12, logits13, logits14, logits15, logits16], dim=2)
+            
+            elif ENABLE_VACAB_SPLIT8:
+                # Use 8-way split head
+                logits1 = self.lm_head8_1(hidden_states).squeeze(2).transpose(1, 2)
+                logits2 = self.lm_head8_2(hidden_states).squeeze(2).transpose(1, 2)
+                logits3 = self.lm_head8_3(hidden_states).squeeze(2).transpose(1, 2)
+                logits4 = self.lm_head8_4(hidden_states).squeeze(2).transpose(1, 2)
+                logits5 = self.lm_head8_5(hidden_states).squeeze(2).transpose(1, 2)
+                logits6 = self.lm_head8_6(hidden_states).squeeze(2).transpose(1, 2)
+                logits7 = self.lm_head8_7(hidden_states).squeeze(2).transpose(1, 2)
+                logits8 = self.lm_head8_8(hidden_states).squeeze(2).transpose(1, 2)
+                
+                if self.enable_coreml and ENABLE_LOGITS2:
+                    return logits1, logits2, logits3, logits4, logits5, logits6, logits7, logits8
+                else:
+                    logits = torch.cat([logits1, logits2, logits3, logits4, logits5, logits6, logits7, logits8], dim=2)
+            
+            elif ENABLE_VACAB_SPLIT:
+                # Use 2-way split head
+                logits1 = self.lm_head2_1(hidden_states).squeeze(2).transpose(1, 2)
+                logits2 = self.lm_head2_2(hidden_states).squeeze(2).transpose(1, 2)
+                
+                if self.enable_coreml and ENABLE_LOGITS2:
+                    return logits1, logits2
+                
+                logits = torch.cat([logits1, logits2], dim=2)
+            
+            else:
+                # Use single head
+                logits = self.lm_head1(hidden_states).squeeze(2).transpose(1, 2)
+        else:
+            # Use linear head (fallback)
+            logits = self.lm_head(hidden_states.permute(0, 2, 1).unsqueeze(2))
+            logits = logits.squeeze(2).permute(0, 2, 1)
+        
+        return logits
+
+    def prefill_kv_cache(self, input_ids, position_ids, start_pos, causal_mask):
+        """
+        Pre-fills KV cache for a batch of tokens starting from start_pos.
+        
+        Args:
+            input_ids: Input token IDs of shape [batch_size, seq_length]
+            position_ids: Position IDs for the sequence
+            start_pos: Starting position in the KV cache
+            causal_mask: Causal attention mask
+            
+        Returns:
+            None (updates KV cache in-place)
+        """
+        batch_size, seq_length = input_ids.shape
+        
+        # Get embeddings and run through model
+        hidden_states = self.model.embed_tokens(input_ids)
+        hidden_states = hidden_states.to(MODEL_DTYPE)
+
+        # Get correct causal mask for the sequence
+        # For prefill, each token should attend to all previous tokens in the sequence
+        if causal_mask is not None:
+            # Take the full sequence slice of causal mask
+            causal_mask_prefill = causal_mask[:, :, :seq_length, :]
+        else:
+            causal_mask_prefill = None
+        
+        # Process through model to update KV cache
+        with torch.no_grad():
+            self.model.forward_prefill(
+                hidden_states=hidden_states,
+                position_ids=position_ids,
+                causal_mask=causal_mask_prefill,
+                current_pos=start_pos
+            )
+
+    def load_pretrained_weights(self, model_path: str) -> bool:
+        if not self.model.load_pretrained_weights(model_path):
+            return False
+        
+        # Load lm_head weights with splitting support
+        state_dict: Dict[str, torch.Tensor] = {}
+        for file in os.listdir(model_path):
+            if file.endswith(".safetensors"):
+                state_dict.update(
+                    safetensors.torch.load_file(os.path.join(model_path, file))
+                )
+        
+        # Handle lm_head weight (following llama_model.py pattern)
+        lm_head_present = False
+        embed_tokens_key = None
+        for k, v in state_dict.items():
+            if k == "lm_head.weight":
+                lm_head_present = True
+            if "embed_tokens.weight" in k:
+                embed_tokens_key = k
+
+        if not lm_head_present:
+            print("lm_head.weight not found in the model file dictionary")
+            if embed_tokens_key:
+                print(f"Using {embed_tokens_key} for lm_head.weight")
+                state_dict['lm_head.weight'] = state_dict[embed_tokens_key].clone()
+            else:
+                print("embed_tokens.weight not found. Unable to set lm_head.weight")
+                return False
+        
+        # Handle lm_head weight loading and splitting
+        lm_head_weight = None
+        for k, v in state_dict.items():
+            if k == "lm_head.weight":
+                lm_head_weight = v
+                break
+        
+        if lm_head_weight is not None:
+            if ENABLE_CONV2D:
+                reshaped_weight = lm_head_weight.view(lm_head_weight.shape[0], lm_head_weight.shape[1], 1, 1)
+                if ENABLE_VACAB_SPLIT16:
+                    vocab_split = self.config.vocab_size // 16
+                    vocab_remainder = self.config.vocab_size % 16
+                    # Create splits with proper sizes, distributing remainder among first splits
+                    split_sizes = [vocab_split + (1 if i < vocab_remainder else 0) for i in range(16)]
+                    splits = torch.split(reshaped_weight, split_sizes)
+                    for i, split in enumerate(splits):
+                        getattr(self, f"lm_head16_{i+1}").weight.data.copy_(split)
+                        print(f"Loaded lm_head16_{i+1}.weight with shape {split.shape}")
+                elif ENABLE_VACAB_SPLIT8:
+                    vocab_split = self.config.vocab_size // 8
+                    vocab_remainder = self.config.vocab_size % 8
+                    # Create splits with proper sizes, distributing remainder among first splits
+                    split_sizes = [vocab_split + (1 if i < vocab_remainder else 0) for i in range(8)]
+                    splits = torch.split(reshaped_weight, split_sizes)
+                    for i, split in enumerate(splits):
+                        getattr(self, f"lm_head8_{i+1}").weight.data.copy_(split)
+                        print(f"Loaded lm_head8_{i+1}.weight with shape {split.shape}")
+                elif ENABLE_VACAB_SPLIT:
+                    vocab_split = self.config.vocab_size // 2
+                    split1, split2 = torch.split(reshaped_weight, [vocab_split, self.config.vocab_size - vocab_split])
+                    self.lm_head2_1.weight.data.copy_(split1)
+                    self.lm_head2_2.weight.data.copy_(split2)
+                    print(f"Loaded lm_head2_1.weight and lm_head2_2.weight")
+                else:
+                    self.lm_head1.weight.data.copy_(reshaped_weight)
+                    print(f"Loaded lm_head1.weight")
+            else:
+                self.lm_head.weight.data.copy_(lm_head_weight.view(lm_head_weight.shape[0], lm_head_weight.shape[1], 1, 1))
+        else:
+            print("Warning: lm_head.weight not found in model weights")
+            return False
+        
+        return True
+

--- a/anemll/models/gemma3_model.py
+++ b/anemll/models/gemma3_model.py
@@ -416,13 +416,13 @@ class Gemma3DecoderLayer(nn.Module):
         hidden_states = self.mlp(normed_hidden_states)
         hidden_states = residual + hidden_states
 
-        present_key_value = attn_outputs[2] if use_cache else None
+        present_key_value = attn_outputs[1] if use_cache and not output_attentions else (attn_outputs[2] if use_cache else None)
 
         outputs = (hidden_states,)
         if output_attentions:
             outputs += (self_attn_weights,)
         if use_cache:
-            outputs += (present_key_value,)
+            outputs += (present_key_value,) if present_key_value is not None else ()
 
         return outputs
         
@@ -659,15 +659,14 @@ class Gemma3Attention(nn.Module):
         attn_output = self.o_proj(attn_output_conv).squeeze(-1).transpose(1, 2)
 
         if not use_cache:
-           
-            return attn_output, attn_weights, None 
+            return attn_output, attn_weights
         else:
-            
-            present_key_value = (key_states, value_states)
+            # The state is returned as a tuple of (key, value)
+            present_key_value = (key_states.to(hidden_states.dtype), value_states.to(hidden_states.dtype))
             if output_attentions:
                 return attn_output, attn_weights, present_key_value
             else:
-                return attn_output, None, present_key_value
+                return attn_output, present_key_value
 
 
            

--- a/anemll/models/gemma3_model.py
+++ b/anemll/models/gemma3_model.py
@@ -64,8 +64,8 @@ class Gemma3Config:
         self.bos_token_id = kwargs.get("bos_token_id", 2)
         self.eos_token_id = kwargs.get("eos_token_id", 1)
         self.hidden_act = kwargs.get("hidden_act", "gelu_pytorch_tanh")
-        #self.hidden_size = kwargs.get("hidden_size", 2304)
-        self.hidden_size = kwargs.get("hidden_size", 2048)
+        self.hidden_size = kwargs.get("hidden_size", 2304)
+        #self.hidden_size = kwargs.get("hidden_size", 2048)
         self.initializer_range = kwargs.get("initializer_range", 0.02)
         self.intermediate_size = kwargs.get("intermediate_size", 9216)
         self.max_position_embeddings = kwargs.get("max_position_embeddings", 131072)
@@ -86,7 +86,7 @@ class Gemma3Config:
         self.torch_required = kwargs.get("torch_dtype", "bfloat16")
         self.transformers_version = kwargs.get("transformers_version", "4.40.0.dev0")
         self.use_cache = kwargs.get("use_cache", True)
-        self.vocab_size = kwargs.get("vocab_size", 262208)
+        self.vocab_size = kwargs.get("vocab_size", 262144)
         self.context_length = kwargs.get("context_length", CONTEXT_LENGTH)
         self.state_length = kwargs.get("state_length", STATE_LENGTH)
         self.pad_token_id = kwargs.get("pad_token_id",0)
@@ -404,10 +404,10 @@ class Gemma3DecoderLayer(nn.Module):
             use_cache=use_cache,
             cache_position=cache_position,
             **kwargs,
-        )
-        #hidden_states = residual + 
+        ) 
 
         attn_output = attn_outputs[0]
+        hidden_states = residual + attn_output
         self_attn_weights = attn_outputs[1] if output_attentions else None
 
         # 2. MLP (Feed-Forward) block
@@ -416,7 +416,7 @@ class Gemma3DecoderLayer(nn.Module):
         hidden_states = self.mlp(normed_hidden_states)
         hidden_states = residual + hidden_states
 
-        present_key_value = attn_outputs[1] if use_cache and not output_attentions else (attn_outputs[2] if use_cache else None)
+        present_key_value = attn_outputs[2] if use_cache else None
 
         outputs = (hidden_states,)
         if output_attentions:
@@ -597,43 +597,87 @@ class Gemma3Attention(nn.Module):
         use_cache: bool = False,
         cache_position: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[tuple[torch.Tensor]]]:
-        
-        # Ensure all inputs are on the correct dtype
+    ) -> tuple[torch.Tensor, torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+
+        # ─────────────────────────────────────────────────────────────
+        # dtype safety (ANE / CoreML)
+        # ─────────────────────────────────────────────────────────────
         hidden_states = hidden_states.to(MODEL_DTYPE)
         cos, sin = position_embeddings
         cos = cos.to(MODEL_DTYPE)
         sin = sin.to(MODEL_DTYPE)
-        position_embeddings = (cos, sin)
 
         if attention_mask is not None:
             attention_mask = attention_mask.to(MODEL_DTYPE)
 
         bsz, q_len, _ = hidden_states.size()
 
-        # Reshape for Conv2d: [batch, seq_len, hidden_size] -> [batch, hidden_size, seq_len, 1]
+        # ─────────────────────────────────────────────────────────────
+        # Conv2d QKV projections
+        # [B, S, H] → [B, H, S, 1]
+        # ─────────────────────────────────────────────────────────────
         hidden_states_conv = hidden_states.transpose(1, 2).unsqueeze(-1)
-        
-        
-        query_states = self.q_proj(hidden_states_conv).squeeze(-1).transpose(1, 2).to(MODEL_DTYPE)
-        key_states = self.k_proj(hidden_states_conv).squeeze(-1).transpose(1, 2).to(MODEL_DTYPE)
-        value_states = self.v_proj(hidden_states_conv).squeeze(-1).transpose(1, 2).to(MODEL_DTYPE)
 
-        query_states = query_states.view(bsz, q_len, self.config.num_attention_heads, self.head_dim).transpose(1, 2)
-        key_states = key_states.view(bsz, q_len, self.config.num_key_value_heads, self.head_dim).transpose(1, 2)
-        value_states = value_states.view(bsz, q_len, self.config.num_key_value_heads, self.head_dim).transpose(1, 2)
+        query_states = (
+            self.q_proj(hidden_states_conv)
+            .squeeze(-1)
+            .transpose(1, 2)
+            .to(MODEL_DTYPE)
+        )
+        key_states = (
+            self.k_proj(hidden_states_conv)
+            .squeeze(-1)
+            .transpose(1, 2)
+            .to(MODEL_DTYPE)
+        )
+        value_states = (
+            self.v_proj(hidden_states_conv)
+            .squeeze(-1)
+            .transpose(1, 2)
+            .to(MODEL_DTYPE)
+        )
 
+        # ─────────────────────────────────────────────────────────────
+        # Reshape to heads
+        # ─────────────────────────────────────────────────────────────
+        query_states = query_states.view(
+            bsz, q_len, self.config.num_attention_heads, self.head_dim
+        ).transpose(1, 2)
+
+        key_states = key_states.view(
+            bsz, q_len, self.config.num_key_value_heads, self.head_dim
+        ).transpose(1, 2)
+
+        value_states = value_states.view(
+            bsz, q_len, self.config.num_key_value_heads, self.head_dim
+        ).transpose(1, 2)
+
+        # ─────────────────────────────────────────────────────────────
+        # QK RMSNorm 
+        # ─────────────────────────────────────────────────────────────
         query_states = self.q_norm(query_states)
         key_states = self.k_norm(key_states)
 
-        # Apply rotary embeddings
-        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+        # ─────────────────────────────────────────────────────────────
+        # Rotary embedding
+        # ─────────────────────────────────────────────────────────────
+        query_states, key_states = apply_rotary_pos_emb(
+            query_states, key_states, cos, sin
+        )
 
-        # Repeat KV heads if using GQA
+        # ─────────────────────────────────────────────────────────────
+        # GQA KV repeat
+        # ─────────────────────────────────────────────────────────────
         key_states = repeat_kv(key_states, self.num_key_value_groups)
         value_states = repeat_kv(value_states, self.num_key_value_groups)
 
-        attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * self.scaling
+        # ─────────────────────────────────────────────────────────────
+        # Attention
+        # ─────────────────────────────────────────────────────────────
+        attn_weights = (
+            torch.matmul(query_states, key_states.transpose(2, 3))
+            * self.scaling
+        )
 
         if self.attn_logit_softcapping is not None:
             attn_weights = attn_weights / self.attn_logit_softcapping
@@ -642,31 +686,44 @@ class Gemma3Attention(nn.Module):
 
         if attention_mask is not None:
             if attention_mask.size() != attn_weights.size():
-                attention_mask = attention_mask[:, :, :q_len, :key_states.shape[-2]]
+                attention_mask = attention_mask[:, :, :q_len, : key_states.shape[-2]]
             attn_weights = attn_weights + attention_mask
 
-        
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1).to(query_states.dtype)
-        attn_weights = nn.functional.dropout(attn_weights, p=self.attention_dropout, training=False)
-        
+        attn_weights = torch.softmax(attn_weights, dim=-1).to(query_states.dtype)
+
+        # dropout 
+        # attn_weights = nn.functional.dropout(attn_weights, p=0.0, training=False)
+
         attn_output = torch.matmul(attn_weights, value_states)
 
-        attn_output = attn_output.transpose(1, 2).contiguous()
-        attn_output = attn_output.reshape(bsz, q_len, self.config.num_attention_heads * self.head_dim)
+        # ─────────────────────────────────────────────────────────────
+        # Merge heads
+        # ─────────────────────────────────────────────────────────────
+        attn_output = (
+            attn_output.transpose(1, 2)
+            .contiguous()
+            .view(bsz, q_len, self.config.num_attention_heads * self.head_dim)
+        )
 
-        # Reshape for o_proj Conv2d
+        # ─────────────────────────────────────────────────────────────
+        # Output projection (Conv2d)
+        # ─────────────────────────────────────────────────────────────
         attn_output_conv = attn_output.transpose(1, 2).unsqueeze(-1)
-        attn_output = self.o_proj(attn_output_conv).squeeze(-1).transpose(1, 2)
+        attn_output = (
+            self.o_proj(attn_output_conv)
+            .squeeze(-1)
+            .transpose(1, 2)
+        )
 
-        if not use_cache:
-            return attn_output, attn_weights
-        else:
-            # The state is returned as a tuple of (key, value)
-            present_key_value = (key_states.to(hidden_states.dtype), value_states.to(hidden_states.dtype))
-            if output_attentions:
-                return attn_output, attn_weights, present_key_value
-            else:
-                return attn_output, present_key_value
+        # ─────────────────────────────────────────────────────────────
+        # ALWAYS return fixed structure (CoreML safe)
+        # ─────────────────────────────────────────────────────────────
+        present_key_value = (
+            key_states.to(hidden_states.dtype),
+            value_states.to(hidden_states.dtype),
+        )
+
+        return attn_output, attn_weights, present_key_value
 
 
            

--- a/anemll/models/gemma3_model.py
+++ b/anemll/models/gemma3_model.py
@@ -220,12 +220,24 @@ class Gemma3RotaryEmbedding(nn.Module):
 
     @torch.no_grad()
     #@dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
-    def forward(self, x, position_ids):
+    def forward(
+        self,
+        x,
+        position_ids,
+        seq_len: Optional[int] = None, 
+    ):
         # Ensure position_ids is 2D for consistent processing
         if position_ids.dim() == 1:
             position_ids = position_ids.unsqueeze(0)
 
-        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        # Truncate or extend inv_freq based on seq_len if provided
+        if seq_len is not None:
+            seq_len = max(seq_len, position_ids.shape[-1])
+            inv_freq = self.inv_freq[:seq_len]
+        else:
+            inv_freq = self.inv_freq
+
+        inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
         position_ids_expanded = position_ids[:, None, :].float()
 
         device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
@@ -235,6 +247,7 @@ class Gemma3RotaryEmbedding(nn.Module):
             cos = emb.cos() * self.attention_scaling
             sin = emb.sin() * self.attention_scaling
 
+        
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
 

--- a/anemll/models/gemma3_model.py
+++ b/anemll/models/gemma3_model.py
@@ -8,10 +8,11 @@ checkpoints with the correct reshaping.  Only the pieces required for the unit
 """
 
 from __future__ import annotations
+from linecache import cache
 import os
 import json
 import math
-from typing import Dict
+from typing import Dict, Optional
 import copy
 
 import safetensors.torch
@@ -44,7 +45,7 @@ CONTEXT_LENGTH = 1024
 FORCE_UNIFIED_CACHE = True  # Force using a single unified KV cache
 ENABLE_UNIFIED_CACHE = True  # Enable unified KV cache by default
 STATE_LENGTH = 512   # KV cache state length
-DISABLE_KV_CACHE = False  # Disable KV cache for simple testing
+DISABLE_KV_CACHE = True  # Disable KV cache for simple testing
 
 # LM head configuration constants (following llama_model.py pattern)
 ENABLE_CONV2D = bool(1)      # Use Conv2d for LM head
@@ -63,7 +64,8 @@ class Gemma3Config:
         self.bos_token_id = kwargs.get("bos_token_id", 2)
         self.eos_token_id = kwargs.get("eos_token_id", 1)
         self.hidden_act = kwargs.get("hidden_act", "gelu_pytorch_tanh")
-        self.hidden_size = kwargs.get("hidden_size", 2304)
+        #self.hidden_size = kwargs.get("hidden_size", 2304)
+        self.hidden_size = kwargs.get("hidden_size", 2048)
         self.initializer_range = kwargs.get("initializer_range", 0.02)
         self.intermediate_size = kwargs.get("intermediate_size", 9216)
         self.max_position_embeddings = kwargs.get("max_position_embeddings", 131072)
@@ -337,7 +339,7 @@ class Gemma3DecoderLayer(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        position_embeddings: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
         attention_mask:torch.Tensor = None,
         position_ids: torch.LongTensor = None,
         past_key_values: [Cache] = None, # type: ignore
@@ -346,8 +348,18 @@ class Gemma3DecoderLayer(nn.Module):
         cache_position: [torch.LongTensor] = None, # type: ignore
         **kwargs,
     ) -> tuple[torch.FloatTensor, Optional[tuple[torch.FloatTensor, torch.FloatTensor]]]:
-        # This is the standard Transformer block structure.
         
+        hidden_states = hidden_states.to(MODEL_DTYPE)
+        
+       
+        position_embeddings_global, position_embeddings_local = position_embeddings
+        position_embeddings_global = position_embeddings_global.to(MODEL_DTYPE)
+        position_embeddings_local = position_embeddings_local.to(MODEL_DTYPE)
+        position_embeddings = (position_embeddings_global, position_embeddings_local)
+
+        if attention_mask is not None:
+            attention_mask = attention_mask.to(MODEL_DTYPE)
+
         # 1. Self-Attention block
         residual = hidden_states
         normed_hidden_states = self.input_layernorm(hidden_states)
@@ -523,25 +535,39 @@ class Gemma3Attention(nn.Module):
 
         self.q_norm = Gemma3RMSNorm(hidden_size=config.head_dim, eps=config.rms_norm_eps)
         self.k_norm = Gemma3RMSNorm(hidden_size=config.head_dim, eps=config.rms_norm_eps)
+        
 
     def forward(
         self,
         hidden_states: torch.Tensor,
-        position_embeddings: torch.Tensor,
-        attention_mask: Optional[torch.Tensor],
-        # Remove unused arguments from transformers-style forward
-        # past_key_values: Optional[Cache] = None,
-        # cache_position: Optional[torch.LongTensor] = None,
-        **kwargs,
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[cache] = None, # type: ignore
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        cache_position: Optional[torch.LongTensor] = None,
+    ) -> tuple[torch.FloatTensor, Optional[torch.FloatTensor]]:
+        
+        # Ensure all inputs are on the correct dtype
+        hidden_states = hidden_states.to(MODEL_DTYPE)
+        cos, sin = position_embeddings
+        cos = cos.to(MODEL_DTYPE)
+        sin = sin.to(MODEL_DTYPE)
+        position_embeddings = (cos, sin)
+
+        if attention_mask is not None:
+            attention_mask = attention_mask.to(MODEL_DTYPE)
+
         bsz, q_len, _ = hidden_states.size()
 
         # Reshape for Conv2d: [batch, seq_len, hidden_size] -> [batch, hidden_size, seq_len, 1]
         hidden_states_conv = hidden_states.transpose(1, 2).unsqueeze(-1)
-
-        query_states = self.q_proj(hidden_states_conv).squeeze(-1).transpose(1, 2)
-        key_states = self.k_proj(hidden_states_conv).squeeze(-1).transpose(1, 2)
-        value_states = self.v_proj(hidden_states_conv).squeeze(-1).transpose(1, 2)
+        
+        
+        query_states = self.q_proj(hidden_states_conv).squeeze(-1).transpose(1, 2).to(MODEL_DTYPE)
+        key_states = self.k_proj(hidden_states_conv).squeeze(-1).transpose(1, 2).to(MODEL_DTYPE)
+        value_states = self.v_proj(hidden_states_conv).squeeze(-1).transpose(1, 2).to(MODEL_DTYPE)
 
         query_states = query_states.view(bsz, q_len, self.config.num_attention_heads, self.head_dim).transpose(1, 2)
         key_states = key_states.view(bsz, q_len, self.config.num_key_value_heads, self.head_dim).transpose(1, 2)
@@ -550,17 +576,8 @@ class Gemma3Attention(nn.Module):
         query_states = self.q_norm(query_states)
         key_states = self.k_norm(key_states)
 
-        # Ensure the output of norm layers is in the correct dtype before RoPE
-        query_states = query_states.to(MODEL_DTYPE)
-        key_states = key_states.to(MODEL_DTYPE)
-
-        cos, sin = position_embeddings
+        # Apply rotary embeddings
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
-
-        # KV Cache is handled by the converter/runner, not in the model forward pass for this implementation
-        # if past_key_values is not None:
-        #     cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
-        #     key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
         # Repeat KV heads if using GQA
         key_states = repeat_kv(key_states, self.num_key_value_groups)
@@ -578,19 +595,23 @@ class Gemma3Attention(nn.Module):
                 attention_mask = attention_mask[:, :, :q_len, :key_states.shape[-2]]
             attn_weights = attn_weights + attention_mask
 
-        # upcast attention to fp32
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+        
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1).to(query_states.dtype)
         attn_weights = nn.functional.dropout(attn_weights, p=self.attention_dropout, training=False)
+        
         attn_output = torch.matmul(attn_weights, value_states)
 
         attn_output = attn_output.transpose(1, 2).contiguous()
-        attn_output = attn_output.reshape(bsz, q_len, self.config.hidden_size)
+        attn_output = attn_output.reshape(bsz, q_len, self.config.num_attention_heads * self.head_dim)
 
         # Reshape for o_proj Conv2d
         attn_output_conv = attn_output.transpose(1, 2).unsqueeze(-1)
         attn_output = self.o_proj(attn_output_conv).squeeze(-1).transpose(1, 2)
 
         return attn_output, attn_weights
+    
+
+           
 
 
 class Gemma3ForCausalLM(nn.Module):
@@ -879,4 +900,3 @@ class Gemma3ForCausalLM(nn.Module):
             return False
         
         return True
-

--- a/anemll/models/gemma3_model.py
+++ b/anemll/models/gemma3_model.py
@@ -142,18 +142,22 @@ class Gemma3MLP(nn.Module):
         self.config = config
         self.hidden_size = config.hidden_size
         self.intermediate_size = config.intermediate_size
-        self.gate_proj = nn.Conv2d(self.hidden_size, self.intermediate_size, 1, bias=False)
-        self.up_proj = nn.Conv2d(self.hidden_size, self.intermediate_size, 1, bias=False)
-        self.down_proj = nn.Conv2d(self.intermediate_size, self.hidden_size, 1, bias=False)
+
+       
+        self.gate_proj = nn.Conv2d(self.hidden_size, self.intermediate_size, kernel_size=1, bias=False, dtype=MODEL_DTYPE)
+        self.up_proj = nn.Conv2d(self.hidden_size, self.intermediate_size, kernel_size=1, bias=False, dtype=MODEL_DTYPE)
+        self.down_proj = nn.Conv2d(self.intermediate_size, self.hidden_size, kernel_size=1, bias=False, dtype=MODEL_DTYPE)
         self.act_fn = ACT2FN[config.hidden_act]
 
     def forward(self, x):
-        # Reshape for Conv2d: [batch, seq_len, hidden_size] -> [batch, hidden_size, seq_len, 1]
-        x = x.transpose(1, 2).unsqueeze(-1)
+        
+        x = x.to(MODEL_DTYPE).permute(0, 2, 1).unsqueeze(2)
+        
         down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
-        # Reshape back: [batch, hidden_size, seq_len, 1] -> [batch, seq_len, hidden_size]
-        return down_proj.squeeze(-1).transpose(1, 2)
-
+        
+       
+        return down_proj.squeeze(2).permute(0, 2, 1)
+    
 class Gemma3RMSNorm(nn.Module):
     """Manual RMSNorm implementation with explicit dtype handling for JIT compatibility."""
 
@@ -376,7 +380,8 @@ class Gemma3DecoderLayer(nn.Module):
         # 1. Self-Attention block
         residual = hidden_states
         normed_hidden_states = self.input_layernorm(hidden_states)
-        attn_outputs, self_attn_weights = self.self_attn(
+
+        attn_outputs = self.self_attn(
             hidden_states=normed_hidden_states,
             position_embeddings=position_embeddings,
             attention_mask=attention_mask,
@@ -387,7 +392,10 @@ class Gemma3DecoderLayer(nn.Module):
             cache_position=cache_position,
             **kwargs,
         )
-        hidden_states = residual + attn_outputs
+        #hidden_states = residual + 
+
+        attn_output = attn_outputs[0]
+        self_attn_weights = attn_outputs[1] if output_attentions else None
 
         # 2. MLP (Feed-Forward) block
         residual = hidden_states
@@ -395,10 +403,13 @@ class Gemma3DecoderLayer(nn.Module):
         hidden_states = self.mlp(normed_hidden_states)
         hidden_states = residual + hidden_states
 
-        outputs = (hidden_states,)
+        present_key_value = attn_outputs[2] if use_cache else None
 
+        outputs = (hidden_states,)
         if output_attentions:
             outputs += (self_attn_weights,)
+        if use_cache:
+            outputs += (present_key_value,)
 
         return outputs
         
@@ -564,12 +575,13 @@ class Gemma3Attention(nn.Module):
         hidden_states: torch.Tensor,
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.LongTensor] = None,
-        past_key_values: Optional[cache] = None, # type: ignore
+        position_ids: Optional[torch.Tensor] = None,
+        past_key_value: Optional[tuple[torch.Tensor]] = None,
         output_attentions: bool = False,
         use_cache: bool = False,
-        cache_position: Optional[torch.LongTensor] = None,
-    ) -> tuple[torch.FloatTensor, Optional[torch.FloatTensor]]:
+        cache_position: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[tuple[torch.Tensor]]]:
         
         # Ensure all inputs are on the correct dtype
         hidden_states = hidden_states.to(MODEL_DTYPE)
@@ -630,8 +642,17 @@ class Gemma3Attention(nn.Module):
         attn_output_conv = attn_output.transpose(1, 2).unsqueeze(-1)
         attn_output = self.o_proj(attn_output_conv).squeeze(-1).transpose(1, 2)
 
-        return attn_output, attn_weights
-    
+        if not use_cache:
+           
+            return attn_output, attn_weights, None 
+        else:
+            
+            present_key_value = (key_states, value_states)
+            if output_attentions:
+                return attn_output, attn_weights, present_key_value
+            else:
+                return attn_output, None, present_key_value
+
 
            
 

--- a/anemll/models/gemma3_model.py
+++ b/anemll/models/gemma3_model.py
@@ -45,7 +45,7 @@ CONTEXT_LENGTH = 1024
 FORCE_UNIFIED_CACHE = True  # Force using a single unified KV cache
 ENABLE_UNIFIED_CACHE = True  # Enable unified KV cache by default
 STATE_LENGTH = 512   # KV cache state length
-DISABLE_KV_CACHE = True  # Disable KV cache for simple testing
+DISABLE_KV_CACHE = False  # Disable KV cache for simple testing
 
 # LM head configuration constants (following llama_model.py pattern)
 ENABLE_CONV2D = bool(1)      # Use Conv2d for LM head
@@ -502,6 +502,15 @@ class Gemma3TextModel(nn.Module):
 
         hidden_states = self.norm(hidden_states)
         return hidden_states
+    
+    def get_rotary_embedding_prefill(self, position_ids: torch.LongTensor):
+        
+        cos_global, sin_global = self.rotary_emb(None, position_ids, seq_len=position_ids.shape[1])
+      
+        cos_local, sin_local = self.rotary_emb_local(None, position_ids, seq_len=position_ids.shape[1])
+
+        
+        return (cos_global, sin_global, cos_local, sin_local)
 
 
 class Gemma3Attention(nn.Module):

--- a/anemll/models/gemma3_model.py
+++ b/anemll/models/gemma3_model.py
@@ -39,7 +39,7 @@ ACT2FN = {
 
 MODEL_DTYPE = torch.float16
 TEST_DEVICE = "cpu"
-CONTEXT_LENGTH = 1024
+CONTEXT_LENGTH = 512
 
 # Cache configuration constants (following llama_model.py pattern)
 FORCE_UNIFIED_CACHE = True  # Force using a single unified KV cache

--- a/anemll/models/gemma3_model.py
+++ b/anemll/models/gemma3_model.py
@@ -49,9 +49,9 @@ DISABLE_KV_CACHE = False  # Disable KV cache for simple testing
 
 # LM head configuration constants (following llama_model.py pattern)
 ENABLE_CONV2D = bool(1)      # Use Conv2d for LM head
-ENABLE_VACAB_SPLIT = bool(1)  # Split vocab into 2 parts
-ENABLE_VACAB_SPLIT8 = bool(0)  # Split vocab into 8 parts
-ENABLE_VACAB_SPLIT16 = bool(1)  # Split vocab into 16 parts
+ENABLE_VACAB_SPLIT = bool(0)  # Split vocab into 2 parts
+ENABLE_VACAB_SPLIT8 = bool(1)  # Split vocab into 8 parts
+ENABLE_VACAB_SPLIT16 = bool(0)  # Split vocab into 16 parts
 ENABLE_LOGITS2 = bool(1)    # Return separate logits arrays for CoreML
 ENABLE_COREML = bool(0)     # CoreML-specific returns
 

--- a/utils/check_dependencies.sh
+++ b/utils/check_dependencies.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-echo "=== ANEMLL DEBUG MARKER ==="
-echo "RUNNING CHECK_DEPENDENCIES.SH FROM: $0"
-
 # check_dependencies.sh
 # This script checks for necessary dependencies before running convert_model.sh
 
@@ -55,7 +52,7 @@ if [ "$SKIP_CHECK" = false ]; then
     fi
 
     echo "Checking if Python is installed..."
-    command -v python >/dev/null 2>&1 || { echo >&2 "Python is required but it's not installed. Aborting. (Issue #1)"; echo "Please refer to the troubleshooting guide in docs/troubleshooting.md for more information."; exit 1; }
+    command -v python3 >/dev/null 2>&1 || { echo >&2 "Python is required but it's not installed. Aborting. (Issue #1)"; echo "Please refer to the troubleshooting guide in docs/troubleshooting.md for more information."; exit 1; }
 
     echo "Checking if pip is installed..."
     command -v pip >/dev/null 2>&1 || { echo >&2 "pip is required but it's not installed. Aborting. (Issue #2)"; echo "Please refer to the troubleshooting guide in docs/troubleshooting.md for more information."; exit 1; }
@@ -151,9 +148,11 @@ if [ "$SKIP_CHECK" = false ]; then
             echo "Alternatively, you can convert this quantized model to unquantized FP16/BF16:"
             echo ""
             echo "  Option 1: Download the original unquantized model from Hugging Face"
-            echo "  Option 2: Use the dequantization script (if available):"
+            echo "  Option 2: Use the HuggingFace dequantization script:"
             echo "           python utils/dequantize_model.py --input $MODEL_DIR --output ./dequantized_model"
-            echo "  Option 3: In Python, load and save as FP16:"
+            echo "  Option 3: Use MLX dequantization (for MLX-compatible models):"
+            echo "           python utils/dequantize_mlx.py --model $MODEL_DIR --save-path ./mlx_dequantized --de-quantize"
+            echo "  Option 4: In Python, load and save as FP16:"
             echo "           from transformers import AutoModelForCausalLM"
             echo "           model = AutoModelForCausalLM.from_pretrained('$MODEL_DIR', device_map='cpu')"
             echo "           model.save_pretrained('./unquantized_model', torch_dtype='float16')"
@@ -173,27 +172,24 @@ if [ "$SKIP_CHECK" = false ]; then
 
         # Check for supported architectures in config.json
         echo "Checking for supported architectures in config.json..."
-        echo "DEBUG: config.json contents:"
-        cat "$MODEL_DIR/config.json"
-
-        CONFIG_ARCH=$(jq -r '.architectures[0] // empty' "$MODEL_DIR/config.json" 2>/dev/null)
-        CONFIG_MODEL_TYPE=$(jq -r '.model_type // empty' "$MODEL_DIR/config.json" 2>/dev/null)
+        SUPPORTED_ARCHS=("llama" "qwen" "gemma3")
+        CONFIG_ARCH=$(jq -r '.architectures[]' "$MODEL_DIR/config.json" 2>/dev/null)
+        CONFIG_MODEL_TYPE=$(jq -r '.model_type' "$MODEL_DIR/config.json" 2>/dev/null)
 
         CONFIG_ARCH_LOWER=$(echo "$CONFIG_ARCH" | tr '[:upper:]' '[:lower:]')
         CONFIG_MODEL_TYPE_LOWER=$(echo "$CONFIG_MODEL_TYPE" | tr '[:upper:]' '[:lower:]')
 
-        echo "DEBUG: CONFIG_ARCH='$CONFIG_ARCH', CONFIG_MODEL_TYPE='$CONFIG_MODEL_TYPE', CONFIG_ARCH_LOWER='$CONFIG_ARCH_LOWER', CONFIG_MODEL_TYPE_LOWER='$CONFIG_MODEL_TYPE_LOWER'"
-
-        if [[ -z "$CONFIG_ARCH_LOWER" && -z "$CONFIG_MODEL_TYPE_LOWER" ]]; then
-            echo "Could not detect architecture or model_type in config.json. Aborting."
-            exit 1
-        fi
-
-        if [[ "$CONFIG_ARCH_LOWER" != *llama* && "$CONFIG_ARCH_LOWER" != *qwen* && "$CONFIG_MODEL_TYPE_LOWER" != *llama* && "$CONFIG_MODEL_TYPE_LOWER" != *qwen* ]]; then
-            echo "Unsupported architecture or model type in config.json. Supported types: llama, qwen. Aborting. (Issue #7)"
-            echo "Detected architectures: $CONFIG_ARCH"
-            echo "Detected model_type: $CONFIG_MODEL_TYPE"
-            echo "(Lowercased: architectures='$CONFIG_ARCH_LOWER', model_type='$CONFIG_MODEL_TYPE_LOWER')"
+        # Check if architecture contains any supported pattern
+        ARCH_SUPPORTED=false
+        for arch in "${SUPPORTED_ARCHS[@]}"; do
+            if [[ "$CONFIG_ARCH_LOWER" == *"$arch"* ]] || [[ "$CONFIG_MODEL_TYPE_LOWER" == *"$arch"* ]]; then
+                ARCH_SUPPORTED=true
+                break
+            fi
+        done
+        
+        if [ "$ARCH_SUPPORTED" = false ]; then
+            echo "Unsupported architecture or model type in config.json. Supported types: ${SUPPORTED_ARCHS[@]}. Aborting. (Issue #7)"
             echo "Please refer to the troubleshooting guide in docs/troubleshooting.md for more information."
             exit 1
         fi

--- a/utils/convert_model.sh
+++ b/utils/convert_model.sh
@@ -20,11 +20,11 @@ MODEL_PATH=""
 OUTPUT_DIR=""
 NUM_CHUNKS=2   # Default number of chunks
 
-# Converter command, determined later
-CONVERTER="python3 -m anemll.ane_converter.llama_converter"
-
 # Initialize SKIP_CHECK before parsing arguments
 SKIP_CHECK=false
+
+# Default converter; may be overridden after parsing config.json
+CONVERTER="python3 -m anemll.ane_converter.llama_converter"
 
 # Initialize SKIP_CHECK before parsing arguments
 SKIP_CHECK=false
@@ -140,17 +140,31 @@ OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)" || {
     OUTPUT_DIR="$(cd "$(dirname "$OUTPUT_DIR")" && pwd)/$(basename "$OUTPUT_DIR")"
 }
 
-# Detect architecture from config.json to choose converter
+# Detect architecture from config.json
 CONFIG_FILE="$MODEL_PATH/config.json"
 if [ -f "$CONFIG_FILE" ]; then
     ARCH=$(jq -r '.model_type // (.architectures[0] // "")' "$CONFIG_FILE" | tr '[:upper:]' '[:lower:]')
-    if [[ "$ARCH" == *qwen* ]]; then
+    # Check for Qwen2 (which is Qwen 2.5) or Qwen2ForCausalLM architecture
+    if [[ "$ARCH" == "qwen2" ]] || [[ "$ARCH" == *"qwen2forcausallm"* ]]; then
+        CONVERTER="python3 -m anemll.ane_converter.qwen2_5_converter"
+        # Use "qwen25" as default prefix for Qwen 2.5 models unless explicitly set
+        if [ "$PREFIX" = "llama" ]; then
+            PREFIX="qwen25"
+        fi
+    elif [[ "$ARCH" == qwen* ]]; then
         CONVERTER="python3 -m anemll.ane_converter.qwen_converter"
-    elif [[ "$ARCH" == *llama* ]]; then
-        CONVERTER="python3 -m anemll.ane_converter.llama_converter"
+        # Use "qwen" as default prefix for Qwen models unless explicitly set
+        if [ "$PREFIX" = "llama" ]; then
+            PREFIX="qwen"
+        fi
+    elif [[ "$ARCH" == gemma3* ]]; then
+        CONVERTER="python3 -m anemll.ane_converter.gemma3_converter"
+        
+        if [ "$PREFIX" = "llama" ]; then
+            PREFIX="gemma3"
+        fi
     else
-        echo "Unsupported architecture or model type in config.json. Supported types: llama, qwen. Aborting. (Issue #7)"
-        exit 1
+        CONVERTER="python3 -m anemll.ane_converter.llama_converter"
     fi
 fi
 
@@ -306,7 +320,15 @@ fi
 
 # Step 7: Copy tokenizer files and create meta.yaml
 if [ "$MODEL_PATH" != "$OUTPUT_DIR" ]; then
-    MODEL_NAME=$(basename "$MODEL_PATH")
+    # Detect HuggingFace cache path and extract proper model name
+    if [[ "$MODEL_PATH" =~ \.cache/huggingface/hub/models--([^/]+)--([^/]+)/snapshots/ ]]; then
+        # Extract org and model name from HF cache path
+        HF_ORG="${BASH_REMATCH[1]}"
+        HF_MODEL="${BASH_REMATCH[2]}"
+        MODEL_NAME="${HF_ORG}-${HF_MODEL}"
+    else
+        MODEL_NAME=$(basename "$MODEL_PATH")
+    fi
     run_step 7 "Copying tokenizer files and creating meta.yaml" "
         # Copy tokenizer files if they exist
         (cp \"$MODEL_PATH/tokenizer.json\" \"$OUTPUT_DIR/\" || true) && \
@@ -317,7 +339,15 @@ if [ "$MODEL_PATH" != "$OUTPUT_DIR" ]; then
         # Create config.json if it doesn't exist
         if [ ! -f \"$OUTPUT_DIR/config.json\" ]; then
             echo \"Creating config.json for iOS tokenizer...\" && \
-            if [[ \"$ARCH\" == qwen* ]]; then
+            if [[ \"$ARCH\" == \"qwen2\" ]] || [[ \"$ARCH\" == *\"qwen2forcausallm\"* ]]; then
+                # Create Qwen 2.5-specific config.json
+                cat > \"$OUTPUT_DIR/config.json\" <<'EOF_CONFIG'
+{
+  \"tokenizer_class\": \"Qwen2Tokenizer\",
+  \"model_type\": \"qwen2\"
+}
+EOF_CONFIG
+            elif [[ \"$ARCH\" == qwen* ]]; then
                 # Create Qwen-specific config.json
                 cat > \"$OUTPUT_DIR/config.json\" <<'EOF_CONFIG'
 {
@@ -330,63 +360,11 @@ EOF_CONFIG
             fi
         fi && \
         
-        # Create meta.yaml
-        python3 - \"$MODEL_NAME\" \"$CONTEXT_LENGTH\" \"$BATCH_SIZE\" \
+        # Create meta.yaml with correct LUT values based on actual file existence
+        python3 \"$PROJECT_ROOT/anemll/utils/generate_meta_yaml.py\" \
+            \"$MODEL_NAME\" \"$CONTEXT_LENGTH\" \"$BATCH_SIZE\" \
             \"${LUT_PART1:-none}\" \"${LUT_PART2:-none}\" \"${LUT_PART3:-none}\" \
-            $NUM_CHUNKS \"$PREFIX\" \"$ARCH\" \"$OUTPUT_DIR/meta.yaml\" <<'EOF_PY'
-import sys
-MODEL_NAME = sys.argv[1]
-CONTEXT = sys.argv[2]
-BATCH = sys.argv[3]
-LUT_EMB = sys.argv[4]
-LUT_FFN = sys.argv[5]
-LUT_LMH = sys.argv[6]
-NUM_CHUNKS = sys.argv[7]
-PREFIX = sys.argv[8]
-ARCH = sys.argv[9]
-OUTFILE = sys.argv[10]
-
-# Construct model names with LUT suffixes if specified
-embeddings_name = f'{PREFIX}_embeddings' + (f'_lut{LUT_EMB}' if LUT_EMB != 'none' else '')
-lmhead_name = f'{PREFIX}_lm_head' + (f'_lut{LUT_LMH}' if LUT_LMH != 'none' else '')
-ffn_base = f'{PREFIX}_FFN_PF' + (f'_lut{LUT_FFN}' if LUT_FFN != 'none' else '')
-
-# Add .mlmodelc extension to model paths
-embeddings_path = f'{embeddings_name}.mlmodelc'
-lmhead_path = f'{lmhead_name}.mlmodelc'
-ffn_path = f'{ffn_base}.mlmodelc'
-
-# Set split_lm_head based on architecture
-split_lm_head = 16 if ARCH.startswith('qwen') else 8
-
-meta = f'''model_info:
-  name: anemll-{MODEL_NAME}-ctx{CONTEXT}
-  version: 0.3.0
-  description: |
-    Demonstarates running {MODEL_NAME} on Apple Neural Engine
-    Context length: {CONTEXT}
-    Batch size: {BATCH}
-    Chunks: {NUM_CHUNKS}
-  license: MIT
-  author: Anemll
-  framework: Core ML
-  language: Python
-  parameters:
-    context_length: {CONTEXT}
-    batch_size: {BATCH}
-    lut_embeddings: {LUT_EMB}
-    lut_ffn: {LUT_FFN}
-    lut_lmhead: {LUT_LMH}
-    num_chunks: {NUM_CHUNKS}
-    model_prefix: {PREFIX}
-    embeddings: {embeddings_path}
-    lm_head: {lmhead_path}
-    ffn: {ffn_path}
-    split_lm_head: {split_lm_head}
-'''
-with open(OUTFILE, 'w') as f:
-    f.write(meta)
-EOF_PY
+            $NUM_CHUNKS \"$PREFIX\" \"$ARCH\" \"$OUTPUT_DIR\"
     "
 fi
 
@@ -394,7 +372,8 @@ fi
 # Step 8: Test with chat.py
 run_step 8 "Testing with chat.py" "python3 \"$PROJECT_ROOT/tests/chat.py\" \
     --meta \"$OUTPUT_DIR/meta.yaml\" \
-    --prompt \"Who are you ?\""
+    --prompt \"Who are you ?\" \
+    --max-tokens 100"
 
 # Print chat.py command for reference
 echo -e "\nTo chat with the model, use:"
@@ -418,4 +397,15 @@ echo "    --tokenizer \"$OUTPUT_DIR\" \\"
 echo "    --context-length $CONTEXT_LENGTH \\"
 echo "    --d \"$OUTPUT_DIR\""
 
-echo "Conversion completed successfully!" 
+echo -e "\nOption 3 - Using Swift CLI (requires building anemll-swift-cli):"
+echo "cd $PROJECT_ROOT/anemll-swift-cli && swift run anemllcli \\"
+echo "    --meta \"$OUTPUT_DIR/meta.yaml\""
+
+echo -e "\nTo prepare model for HuggingFace upload:"
+echo "# For standard distribution:"
+echo "./anemll/utils/prepare_hf.sh --input \"$OUTPUT_DIR\""
+echo ""
+echo "# For iOS-ready version (with unzipped MLMODELC files):"
+echo "./anemll/utils/prepare_hf.sh --input \"$OUTPUT_DIR\" --ios"
+
+echo -e "\nConversion completed successfully!"


### PR DESCRIPTION
### Gemma3 Support 🚀 #9

This PR introduces CoreML conversion support for Gemma 3 models through a new custom converter (`gemma3_converter.py`) and a new custom model (`gemma3_model.py`).

### 🧪 Test Status and Environment

* **Current Status**: Model load and `ct.convert` succeeded without errors.



* `coremltools` version: **8.3** (currently tested on 9.0)

### ⚠️ Known Issues

- The quality of the generated text is not yet on par with the reference implementation.
- This is likely related to the alignment of the tokenizer and LM head vocabulary in the Swift inference pipeline, or the mapping of split LM head indices.
- CoreML conversion, model loading, and token generation have been confirmed to work properly.

### 🗒️ Note

 In this PR, `Inference Manager.swift` has been modified specifically for Gemma 3, so models like Llama and Qwen may not work.