### PR TITLE
Fix race condition during macOS scrolling

### DIFF
--- a/ANEMLLChat/ANEMLLChat/Models/Conversation.swift
+++ b/ANEMLLChat/ANEMLLChat/Models/Conversation.swift
@@ -123,7 +123,7 @@ extension Conversation {
 
     /// Preview of the last message
     var lastMessagePreview: String? {
-        guard let lastMessage = messages.last(where: { $0.role != .system }) else {
+        guard let lastMessage = messages.last(where: { $0.role != .system && !$0.content.isEmpty }) else {
             return nil
         }
         let preview = lastMessage.content.prefix(60)

--- a/ANEMLLChat/ANEMLLChat/Services/InferenceService.swift
+++ b/ANEMLLChat/ANEMLLChat/Services/InferenceService.swift
@@ -261,65 +261,106 @@ final class InferenceService: ObservableObject {
             isGenerating = false
         }
 
-        // Convert messages to tokenizer format
-        var chatMessages: [Tokenizer.ChatMessage] = []
+        let capturedTemplate = currentTemplate
+        let capturedSystemPrompt = systemPrompt
+        let capturedConfig = config
+        let capturedTokenizerForPrep = tokenizer
 
-        // Add system prompt if not present (resolve markers to actual prompts)
-        if !messages.contains(where: { $0.role == .system }) {
-            let resolvedPrompt = resolveSystemPrompt(systemPrompt)
-            print("===== [SYSTEM PROMPT] Template: \(currentTemplate), Raw: '\(systemPrompt)', Resolved: '\(resolvedPrompt)' =====")
-            logInfo("System prompt resolved: template=\(currentTemplate), prompt=\(resolvedPrompt)", category: .inference)
-            if !resolvedPrompt.isEmpty {
-                chatMessages.append(.system(resolvedPrompt))
-            }
+        struct PreparedInput {
+            let chatMessages: [Tokenizer.ChatMessage]
+            let inputTokens: [Int]
+            let contextLength: Int
+            let maxContextSize: Int
+            let historyTrimmed: Bool
+            let originalSize: Int
         }
 
-        for message in messages {
-            switch message.role {
-            case .system:
-                chatMessages.append(.system(message.content))
-            case .user:
-                chatMessages.append(.user(message.content))
-            case .assistant:
-                chatMessages.append(.assistant(message.content))
-            }
-        }
+        let prepared = await Task.detached(priority: .userInitiated) {
+            () -> PreparedInput in
+            // Convert messages to tokenizer format
+            var chatMessages: [Tokenizer.ChatMessage] = []
 
-        // Get context limits (match CLI: use stateLength if available, otherwise contextLength)
-        let contextLength = config?.contextLength ?? 512
-        let stateLength = (config?.stateLength ?? 0) > 0 ? config!.stateLength : contextLength
-        let maxContextSize = stateLength - 100  // Leave room for response (match CLI/Python)
-
-        // Tokenize and check size
-        var inputTokens = tokenizer.applyChatTemplate(
-            input: chatMessages,
-            addGenerationPrompt: true
-        )
-
-        // Trim history if exceeds context (match CLI behavior)
-        let originalSize = inputTokens.count
-        var historyTrimmed = false
-        while inputTokens.count > maxContextSize && chatMessages.count > 2 {
-            historyTrimmed = true
-            // Remove oldest message pair (user + assistant) like CLI does
-            // Skip system prompt if present (index 0)
-            let startIndex = (chatMessages.first?.role == "system") ? 1 : 0
-            if chatMessages.count > startIndex + 2 {
-                chatMessages.remove(at: startIndex)  // Remove oldest user
-                if chatMessages.count > startIndex {
-                    chatMessages.remove(at: startIndex)  // Remove oldest assistant
-                }
-                inputTokens = tokenizer.applyChatTemplate(
-                    input: chatMessages,
-                    addGenerationPrompt: true
+            // Add system prompt if not present (resolve markers to actual prompts)
+            if !messages.contains(where: { $0.role == .system }) {
+                let resolvedPrompt = InferenceService.resolveSystemPrompt(
+                    capturedSystemPrompt,
+                    template: capturedTemplate
                 )
-            } else {
-                break
+                if !resolvedPrompt.isEmpty {
+                    chatMessages.append(.system(resolvedPrompt))
+                }
             }
+
+            for message in messages {
+                switch message.role {
+                case .system:
+                    chatMessages.append(.system(message.content))
+                case .user:
+                    chatMessages.append(.user(message.content))
+                case .assistant:
+                    chatMessages.append(.assistant(message.content))
+                }
+            }
+
+            // Get context limits (match CLI: use stateLength if available, otherwise contextLength)
+            let contextLength = capturedConfig?.contextLength ?? 512
+            let stateLength = (capturedConfig?.stateLength ?? 0) > 0 ? (capturedConfig?.stateLength ?? contextLength) : contextLength
+            let maxContextSize = stateLength - 100  // Leave room for response (match CLI/Python)
+
+            // Tokenize and check size
+            var inputTokens = capturedTokenizerForPrep.applyChatTemplate(
+                input: chatMessages,
+                addGenerationPrompt: true
+            )
+
+            // Trim history if exceeds context (match CLI behavior)
+            let originalSize = inputTokens.count
+            var historyTrimmed = false
+            while inputTokens.count > maxContextSize && chatMessages.count > 2 {
+                historyTrimmed = true
+                // Remove oldest message pair (user + assistant) like CLI does
+                // Skip system prompt if present (index 0)
+                let startIndex = (chatMessages.first?.role == "system") ? 1 : 0
+                if chatMessages.count > startIndex + 2 {
+                    chatMessages.remove(at: startIndex)  // Remove oldest user
+                    if chatMessages.count > startIndex {
+                        chatMessages.remove(at: startIndex)  // Remove oldest assistant
+                    }
+                    inputTokens = capturedTokenizerForPrep.applyChatTemplate(
+                        input: chatMessages,
+                        addGenerationPrompt: true
+                    )
+                } else {
+                    break
+                }
+            }
+
+            return PreparedInput(
+                chatMessages: chatMessages,
+                inputTokens: inputTokens,
+                contextLength: contextLength,
+                maxContextSize: maxContextSize,
+                historyTrimmed: historyTrimmed,
+                originalSize: originalSize
+            )
+        }.value
+
+        let chatMessages = prepared.chatMessages
+        let inputTokens = prepared.inputTokens
+        let contextLength = prepared.contextLength
+        let maxContextSize = prepared.maxContextSize
+
+        if !messages.contains(where: { $0.role == .system }) {
+            let resolvedPrompt = InferenceService.resolveSystemPrompt(
+                capturedSystemPrompt,
+                template: capturedTemplate
+            )
+            print("===== [SYSTEM PROMPT] Template: \(capturedTemplate), Raw: '\(capturedSystemPrompt)', Resolved: '\(resolvedPrompt)' =====")
+            logInfo("System prompt resolved: template=\(capturedTemplate), prompt=\(resolvedPrompt)", category: .inference)
         }
 
-        if historyTrimmed {
-            print("[SYSTEM] History trimmed: \(originalSize) → \(inputTokens.count) tokens, \(chatMessages.count) msgs remaining")
+        if prepared.historyTrimmed {
+            print("[SYSTEM] History trimmed: \(prepared.originalSize) → \(inputTokens.count) tokens, \(chatMessages.count) msgs remaining")
         }
 
         // Debug: print messages being sent to tokenizer
@@ -340,47 +381,94 @@ final class InferenceService: ObservableObject {
         let stats = GenerationStats()
         let startTime = Date()
 
-        // Capture values we need in nonisolated closures
+        // Capture values we need in detached task
         let capturedRepetitionDetector = repetitionDetector
         let capturedInferenceManager = inferenceManager
         let capturedRepetitionEnabled = repetitionDetectionEnabled
+        let capturedTemperature = temperature
+        let capturedMaxTokens = maxTokens
+        let capturedTokenizer = tokenizer
+        let capturedDebugLevel = debugLevel
         let inputTokenCount = inputTokens.count  // Capture for history calculation
 
         do {
-            let (_, prefillTime, stopReason) = try await inferenceManager.generateResponse(
-                initialTokens: inputTokens,
-                temperature: temperature,
-                maxTokens: maxTokens,
-                eosTokens: tokenizer.eosTokenIds,
-                tokenizer: tokenizer,
-                onToken: { token in
-                    // Check for repetition only if enabled (non-isolated access)
-                    if capturedRepetitionEnabled {
-                        capturedRepetitionDetector.addToken(token)
-                        if capturedRepetitionDetector.isRepeating() {
-                            logWarning("Repetition detected, aborting", category: .inference)
-                            capturedInferenceManager.AbortGeneration(Code: 2)
-                            return
-                        }
-                    }
+            let (prefillTime, stopReason) = try await Task.detached(priority: .userInitiated) {
+                () async throws -> (TimeInterval, String) in
+                var pendingText = ""
+                var lastEmitTime = CFAbsoluteTimeGetCurrent()
+                var lastHistoryEmitTime = lastEmitTime
+                let emitInterval: CFAbsoluteTime = 1.0 / 30.0
+                let minChunkChars = 48
+                var lastTokenLogTime = CFAbsoluteTimeGetCurrent()
+                var lastTokenCount = 0
 
-                    stats.tokenCount += 1
-                    let text = tokenizer.decode(tokens: [token])
-                    stats.generatedText += text
-
-                    onToken(text)
-
-                    // Report current historyTokens (input + output so far)
-                    // Update every 5 tokens to avoid too frequent UI updates
-                    if stats.tokenCount % 5 == 0 || stats.tokenCount == 1 {
-                        onHistoryUpdate?(inputTokenCount + stats.tokenCount)
-                    }
-                },
-                onWindowShift: {
-                    stats.windowShifts += 1
-                    onWindowShift()
+                if capturedDebugLevel >= 2 {
+                    logDebug("[Inference] start threadMain=\(Thread.isMainThread)", category: .inference)
                 }
-            )
+
+                func emitIfNeeded(force: Bool = false) {
+                    let now = CFAbsoluteTimeGetCurrent()
+                    let shouldEmit = force || now - lastEmitTime >= emitInterval || pendingText.count >= minChunkChars
+
+                    if shouldEmit, !pendingText.isEmpty {
+                        let chunk = pendingText
+                        pendingText = ""
+                        lastEmitTime = now
+                        onToken(chunk)
+                    }
+
+                    if let onHistoryUpdate, force || now - lastHistoryEmitTime >= emitInterval {
+                        lastHistoryEmitTime = now
+                        onHistoryUpdate(inputTokenCount + stats.tokenCount)
+                    }
+                }
+
+                let (_, prefillTime, stopReason) = try await capturedInferenceManager.generateResponse(
+                    initialTokens: inputTokens,
+                    temperature: capturedTemperature,
+                    maxTokens: capturedMaxTokens,
+                    eosTokens: capturedTokenizer.eosTokenIds,
+                    tokenizer: capturedTokenizer,
+                    onToken: { token in
+                        // Check for repetition only if enabled
+                        if capturedRepetitionEnabled {
+                            capturedRepetitionDetector.addToken(token)
+                            if capturedRepetitionDetector.isRepeating() {
+                                logWarning("Repetition detected, aborting", category: .inference)
+                                capturedInferenceManager.AbortGeneration(Code: 2)
+                                return
+                            }
+                        }
+
+                        stats.tokenCount += 1
+                        let text = capturedTokenizer.decode(tokens: [token])
+                        stats.generatedText += text
+
+                        pendingText += text
+                        emitIfNeeded()
+
+                        if capturedDebugLevel >= 2 {
+                            let now = CFAbsoluteTimeGetCurrent()
+                            if now - lastTokenLogTime >= 1.0 {
+                                let delta = stats.tokenCount - lastTokenCount
+                                lastTokenCount = stats.tokenCount
+                                lastTokenLogTime = now
+                                logDebug("[Decode] +\(delta) tok/s pendingChars=\(pendingText.count)", category: .inference)
+                            }
+                        }
+                    },
+                    onWindowShift: {
+                        stats.windowShifts += 1
+                        onWindowShift()
+                    }
+                )
+                emitIfNeeded(force: true)
+                return (prefillTime, stopReason)
+            }.value
+
+            if capturedDebugLevel >= 2 {
+                logDebug("[Inference] prefill=\(String(format: "%.3f", prefillTime))s stop=\(stopReason)", category: .inference)
+            }
 
             let totalTime = Date().timeIntervalSince(startTime)
             let tokensPerSecond = totalTime > 0 ? Double(stats.tokenCount) / totalTime : 0
@@ -391,6 +479,8 @@ final class InferenceService: ObservableObject {
             // Total history tokens = input (prefill) + output (generated) - matches CLI behavior
             let historyTokens = inputTokens.count + stats.tokenCount
 
+            let wasCancelled = shouldCancel || stopReason.hasPrefix("abort_generation1")
+
             return GenerationResult(
                 text: stats.generatedText,
                 tokensPerSecond: tokensPerSecond,
@@ -400,7 +490,7 @@ final class InferenceService: ObservableObject {
                 prefillTokens: inputTokens.count,  // For prefill speed calculation
                 historyTokens: historyTokens,       // Total history like CLI shows
                 isComplete: true,
-                wasCancelled: shouldCancel,
+                wasCancelled: wasCancelled,
                 stopReason: stopReason
             )
 
@@ -435,7 +525,7 @@ final class InferenceService: ObservableObject {
     // MARK: - Helpers
 
     /// Resolve system prompt marker to actual prompt based on model template
-    private func resolveSystemPrompt(_ prompt: String) -> String {
+    nonisolated private static func resolveSystemPrompt(_ prompt: String, template: String) -> String {
         // If empty or doesn't start with marker, return as-is
         guard prompt.hasPrefix("[MODEL_") else {
             return prompt
@@ -471,7 +561,7 @@ final class InferenceService: ObservableObject {
             "default": "You are a helpful assistant."
         ]
 
-        let template = currentTemplate.lowercased()
+        let template = template.lowercased()
 
         switch prompt {
         case "[MODEL_DEFAULT]":

--- a/ANEMLLChat/ANEMLLChat/ViewModels/ChatViewModel.swift
+++ b/ANEMLLChat/ANEMLLChat/ViewModels/ChatViewModel.swift
@@ -42,6 +42,24 @@ final class ChatViewModel {
     /// Current history tokens during streaming (input + output so far)
     var currentHistoryTokens: Int = 0
 
+    /// Request the chat view to scroll to bottom before inference starts
+    var pendingScrollToBottomRequest: UUID?
+
+    // UI lag tracing (debug)
+    private var lastUiLagLogTime: CFAbsoluteTime = 0
+    private let uiLagLogCooldown: CFAbsoluteTime = 0.5
+
+    /// Current debug level (mirrors inference service)
+    var debugLevel: Int {
+        inferenceService.debugLevel
+    }
+
+    /// Pause streaming UI updates while user is actively scrolling
+    var uiUpdatesPaused: Bool = false
+    private var pendingStreamingText: String = ""
+    private var pendingHistoryTokens: Int?
+    private var pendingWindowShifts: Int = 0
+
     // MARK: - Dependencies
 
     private let inferenceService = InferenceService.shared
@@ -175,6 +193,15 @@ final class ChatViewModel {
         currentHistoryTokens = 0
         errorMessage = nil
 
+        // Give the UI a chance to show the dots and scroll to the bottom before inference begins
+        let preScrollId = UUID()
+        pendingScrollToBottomRequest = preScrollId
+        await Task.yield()
+        try? await Task.sleep(for: .milliseconds(400))
+        if pendingScrollToBottomRequest == preScrollId {
+            pendingScrollToBottomRequest = nil
+        }
+
         do {
             // Get messages for context (exclude the empty assistant message)
             let contextMessages = conversation.messages.filter {
@@ -184,23 +211,42 @@ final class ChatViewModel {
             let result = try await inferenceService.generateResponse(
                 for: contextMessages,
                 onToken: { [weak self] token in
+                    let enqueueTime = CFAbsoluteTimeGetCurrent()
                     Task { @MainActor in
                         guard let self = self else { return }
-                        self.streamingContent += token
-                        self.updateStreamingMessage()
+                        let delayMs = (CFAbsoluteTimeGetCurrent() - enqueueTime) * 1000
+                        self.traceMainThreadLag(kind: "token", delayMs: delayMs)
+                        if self.uiUpdatesPaused {
+                            self.pendingStreamingText += token
+                        } else {
+                            self.streamingContent += token
+                        }
                     }
                 },
                 onWindowShift: { [weak self] in
+                    let enqueueTime = CFAbsoluteTimeGetCurrent()
                     Task { @MainActor in
                         guard let self = self else { return }
-                        self.currentWindowShifts += 1
+                        let delayMs = (CFAbsoluteTimeGetCurrent() - enqueueTime) * 1000
+                        self.traceMainThreadLag(kind: "windowShift", delayMs: delayMs)
+                        if self.uiUpdatesPaused {
+                            self.pendingWindowShifts += 1
+                        } else {
+                            self.currentWindowShifts += 1
+                        }
                     }
                 },
                 onHistoryUpdate: { [weak self] historyTokens in
+                    let enqueueTime = CFAbsoluteTimeGetCurrent()
                     Task { @MainActor in
                         guard let self = self else { return }
-                        self.currentHistoryTokens = historyTokens
-                        self.updateStreamingMessage()
+                        let delayMs = (CFAbsoluteTimeGetCurrent() - enqueueTime) * 1000
+                        self.traceMainThreadLag(kind: "history", delayMs: delayMs)
+                        if self.uiUpdatesPaused {
+                            self.pendingHistoryTokens = historyTokens
+                        } else {
+                            self.currentHistoryTokens = historyTokens
+                        }
                     }
                 }
             )
@@ -241,22 +287,52 @@ final class ChatViewModel {
         streamingContent = ""
     }
 
+    func setUIUpdatesPaused(_ paused: Bool) {
+        guard paused != uiUpdatesPaused else { return }
+        uiUpdatesPaused = paused
+
+        if inferenceService.debugLevel >= 2 {
+            logDebug("[UI Pause] \(paused ? "paused" : "resumed") pendingChars=\(pendingStreamingText.count)", category: .ui)
+        }
+
+        if !paused {
+            flushPendingStreamingUpdates()
+        }
+    }
+
+    private func flushPendingStreamingUpdates() {
+        if !pendingStreamingText.isEmpty {
+            streamingContent += pendingStreamingText
+            pendingStreamingText = ""
+        }
+
+        if let history = pendingHistoryTokens {
+            currentHistoryTokens = history
+            pendingHistoryTokens = nil
+        }
+
+        if pendingWindowShifts > 0 {
+            currentWindowShifts += pendingWindowShifts
+            pendingWindowShifts = 0
+        }
+    }
+
+    private func traceMainThreadLag(kind: String, delayMs: Double) {
+        guard inferenceService.debugLevel >= 2 else { return }
+        guard delayMs >= 50 else { return }
+
+        let now = CFAbsoluteTimeGetCurrent()
+        if now - lastUiLagLogTime < uiLagLogCooldown {
+            return
+        }
+        lastUiLagLogTime = now
+
+        logWarning("[UI Lag] \(kind) update delayed \(Int(delayMs))ms", category: .ui)
+    }
+
     /// Cancel ongoing generation
     func cancelGeneration() {
         inferenceService.cancelGeneration()
-    }
-
-    /// Update the streaming message in the current conversation
-    private func updateStreamingMessage() {
-        guard var conversation = currentConversation else { return }
-
-        conversation.updateLastAssistantMessage(
-            content: streamingContent,
-            windowShifts: currentWindowShifts,
-            historyTokens: currentHistoryTokens > 0 ? currentHistoryTokens : nil
-        )
-
-        currentConversation = conversation
     }
 
     /// Update a conversation in the list

--- a/ANEMLLChat/ANEMLLChat/Views/Chat/ChatView.swift
+++ b/ANEMLLChat/ANEMLLChat/Views/Chat/ChatView.swift
@@ -6,6 +6,11 @@
 //
 
 import SwiftUI
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
 
 struct ChatView: View {
     @Environment(ChatViewModel.self) private var chatVM
@@ -13,6 +18,7 @@ struct ChatView: View {
 
     @State private var scrollProxy: ScrollViewProxy?
     @State private var scrollMode: ScrollMode = .manual
+    @State private var autoFollowSuspendedByUser = false
     @State private var showScrollToBottom = false
     @State private var autoScrollTask: Task<Void, Never>?
     @State private var lastAutoScrollTime: Date = .distantPast
@@ -20,14 +26,36 @@ struct ChatView: View {
     @State private var hasContentBelow = false  // True when content extends below visible area
     @State private var wasAtBottomBeforeSend = false  // Track if user was at bottom when sending
     @State private var hasScrolledToQuestion = false  // Track if we've done the initial scroll to question
+    @State private var userInteractedDuringGeneration = false
+    @State private var streamingBuffer = StreamingBuffer()
+    @State private var isUserDragging = false
+    @State private var geometryBuffer = GeometryBuffer()
+    @State private var scrollIdleTask: Task<Void, Never>?
+    @State private var uiPauseLockedByUser = false
+    @State private var isProgrammaticScroll = false
+    @State private var programmaticScrollTask: Task<Void, Never>?
 
     private let autoScrollInterval: TimeInterval = 0.07
-    private let bottomVisibilityPadding: CGFloat = 4
+    private let bottomVisibilityPadding: CGFloat = 12
+    private let scrollIdleDelayMs: Int = 180
     private let topFadeHeight: CGFloat = 72
     private let bottomScrimExtra: CGFloat = 56
 
     private var contentBottomPadding: CGFloat {
         max(24, inputAccessoryHeight + 48)  // Padding to keep content above input box with some clearance
+    }
+
+    private var typingPeekHeight: CGFloat {
+        #if os(iOS)
+        UIFont.preferredFont(forTextStyle: .body).lineHeight
+        #else
+        let font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+        return font.ascender - font.descender + font.leading
+        #endif
+    }
+
+    private var bottomScrollExtra: CGFloat {
+        max(12, typingPeekHeight + 8)
     }
 
     private var scrollButtonBottomPadding: CGFloat {
@@ -36,6 +64,10 @@ struct ChatView: View {
     
     private var bottomScrimHeight: CGFloat {
         max(48, inputAccessoryHeight + bottomScrimExtra)
+    }
+
+    private var uiTraceEnabled: Bool {
+        chatVM.debugLevel >= 2
     }
 
     var body: some View {
@@ -64,7 +96,9 @@ struct ChatView: View {
             // Scroll to bottom button (centered horizontally, above input bar)
             if showScrollToBottom {
                 Button {
+                    autoFollowSuspendedByUser = false
                     setScrollMode(.follow)
+                    unlockUIUpdatesFromUser()
                     scrollToBottom(animated: true, toAbsoluteBottom: true)
                     // Update chevron visibility after scroll
                     Task { @MainActor in
@@ -99,12 +133,17 @@ struct ChatView: View {
         }
         .onChange(of: chatVM.currentConversation?.id) { _, _ in
             setScrollMode(.manual)
-            // Don't reset hasContentBelow - let onScrollGeometryChange determine it
+            autoFollowSuspendedByUser = false
+            // Don't reset hasContentBelow - let layout preferences determine it
             // Force chevron visibility check after content loads
             Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(200))
                 updateChevronVisibility()
             }
+        }
+        .onChange(of: chatVM.pendingScrollToBottomRequest) { _, requestId in
+            guard requestId != nil else { return }
+            scrollToBottom(animated: true, toAbsoluteBottom: true)
         }
         .onChange(of: hasContentBelow) { _, _ in
             updateChevronVisibility()
@@ -117,6 +156,7 @@ struct ChatView: View {
                 // 3. Scroll up just enough to show the loading dots below user's question
                 wasAtBottomBeforeSend = !hasContentBelow
                 hasScrolledToQuestion = false
+                userInteractedDuringGeneration = false
                 setScrollMode(.manual)
 
                 // If user was at bottom, scroll up just enough to show the dots
@@ -127,11 +167,13 @@ struct ChatView: View {
                     // Scroll to show the streaming indicator (dots) just below the user's question
                     // This gives user feedback that generation has started
                     Task { @MainActor in
-                        try? await Task.sleep(for: .milliseconds(50))
-                        withAnimation(.easeOut(duration: 0.15)) {
-                            // Scroll to streaming view with anchor near bottom
-                            // This shows: user question + dots + some space above input
-                            scrollProxy?.scrollTo("streaming", anchor: .bottom)
+                        await Task.yield()
+                        if !userInteractedDuringGeneration && chatVM.pendingScrollToBottomRequest == nil {
+                            withAnimation(.easeOut(duration: 0.15)) {
+                                // Scroll to typing peek so dots + prompt are visible
+                                beginProgrammaticScroll()
+                                scrollProxy?.scrollTo("typing-peek", anchor: .bottom)
+                            }
                         }
                     }
                 }
@@ -140,6 +182,7 @@ struct ChatView: View {
                 // - Reset tracking state
                 // - Scroll to last message to ensure proper geometry detection
                 // - Update chevron visibility
+                unlockUIUpdatesFromUser()
                 hasScrolledToQuestion = false
 
                 // Scroll to the completed message to update geometry
@@ -147,6 +190,7 @@ struct ChatView: View {
                     try? await Task.sleep(for: .milliseconds(100))
                     if let lastMsg = visibleMessages.last {
                         withAnimation(.easeOut(duration: 0.2)) {
+                            beginProgrammaticScroll()
                             scrollProxy?.scrollTo(lastMsg.id, anchor: .bottom)
                         }
                     }
@@ -154,49 +198,11 @@ struct ChatView: View {
                     try? await Task.sleep(for: .milliseconds(150))
                     updateChevronVisibility()
 
-                    // Set mode based on updated geometry
-                    if !hasContentBelow {
-                        setScrollMode(.follow)
-                    }
                 }
             }
         }
         .onChange(of: chatVM.streamingContent) { _, content in
-            // During streaming:
-            // 1. When first tokens arrive (>20 chars) and user was at bottom - scroll to position question at top
-            // 2. Then let content fill downward (no more auto-scroll)
-            // 3. Update chevron visibility as content grows
-            if chatVM.isGenerating && !content.isEmpty {
-                // First tokens arrived - scroll so user's question is at the TOP of viewport
-                // Wait for at least ~20 chars so there's visible content before scrolling
-                if wasAtBottomBeforeSend && !hasScrolledToQuestion && content.count > 20 {
-                    hasScrolledToQuestion = true
-                    // Find the last user message ID to scroll to
-                    if let lastUserMessage = visibleMessages.last(where: { $0.role == .user }) {
-                        Task { @MainActor in
-                            try? await Task.sleep(for: .milliseconds(50))
-                            withAnimation(.easeOut(duration: 0.3)) {
-                                // Scroll user's question to TOP of viewport (anchor: .top)
-                                // This positions the question at the very top with answer filling below
-                                scrollProxy?.scrollTo(lastUserMessage.id, anchor: .top)
-                            }
-                        }
-                    }
-                }
-
-                // As content grows, check if it extends below visible area
-                // During streaming, we assume content below if we've scrolled to question
-                // and have substantial content (likely extends below fold)
-                if hasScrolledToQuestion && content.count > 200 {
-                    // Content is likely below visible area, show chevron
-                    if !showScrollToBottom {
-                        showScrollToBottom = true
-                    }
-                }
-
-                // Also always update chevron based on geometry
-                updateChevronVisibility()
-            }
+            bufferStreamingChange(content)
         }
         .onAppear {
             setScrollMode(.manual)
@@ -212,6 +218,7 @@ struct ChatView: View {
                         LazyVStack(spacing: 14) {
                             ForEach(visibleMessages) { message in
                                 MessageBubble(message: message)
+                                    .equatable()
                                     .id(message.id)
                             }
 
@@ -219,23 +226,48 @@ struct ChatView: View {
                             if chatVM.isGenerating {
                                 StreamingMessageView(content: chatVM.streamingContent)
                                     .id("streaming")
+
+                                if chatVM.streamingContent.isEmpty {
+                                    Color.clear
+                                        .frame(height: typingPeekHeight)
+                                        .id("typing-peek")
+                                }
                             }
 
                             // Bottom spacer - anchor point for scroll
                             Color.clear
-                                .frame(height: 8)
+                                .frame(height: contentBottomPadding + bottomScrollExtra)
                                 .id("bottom")
                         }
                         .padding(.horizontal, 18)
                         .padding(.top, 16)
-                        .padding(.bottom, contentBottomPadding)
                     }
                     .mask(topFadeMask)
                     .simultaneousGesture(
                         DragGesture(minimumDistance: 2)
-                            .onChanged { _ in
-                                setScrollMode(.manual)
-                                // hasContentBelow is now updated by onScrollGeometryChange
+                            .onChanged { value in
+                                if uiTraceEnabled && !isUserDragging {
+                                    isUserDragging = true
+                                    logDebug("[Scroll] drag begin generating=\(chatVM.isGenerating) follow=\(scrollMode == .follow) hasBelow=\(hasContentBelow)", category: .ui)
+                                }
+                                markScrollActivity()
+
+                                if chatVM.isGenerating {
+                                    userInteractedDuringGeneration = true
+                                    showScrollToBottom = true
+                                }
+
+                                // On iOS, dragging down scrolls "up" (toward older messages).
+                                let isScrollingUp = value.translation.height > 0
+                                if scrollMode == .follow && isScrollingUp {
+                                    pauseAutoFollowDueToUserScroll()
+                                }
+                            }
+                            .onEnded { _ in
+                                if uiTraceEnabled && isUserDragging {
+                                    logDebug("[Scroll] drag end", category: .ui)
+                                }
+                                isUserDragging = false
                             }
                     )
                     .onAppear {
@@ -246,23 +278,54 @@ struct ChatView: View {
                             scheduleAutoScroll()
                         }
                     }
-                    .onChange(of: chatVM.streamingContent) { _, _ in
-                        if scrollMode == .follow {
-                            scheduleAutoScroll()
+                    .onScrollGeometryChange(for: Double.self) { geometry in
+                        Double(geometry.visibleRect.minY)
+                    } action: { oldValue, newValue in
+                        if chatVM.isGenerating && abs(newValue - oldValue) > 0.5 {
+                            markScrollActivity()
+                        }
+
+                        if isProgrammaticScroll { return }
+
+                        // In scroll coordinates, scrolling "up" decreases `visibleRect.minY`.
+                        let delta = newValue - oldValue
+                        guard delta < -0.5 else { return }
+
+                        Task { @MainActor in
+                            await Task.yield()
+                            pauseAutoFollowDueToUserScroll()
                         }
                     }
-                    // iOS 18+: Detect when content extends below visible area
-                    .onScrollGeometryChange(for: Bool.self) { geometry in
-                        // Content is below visible if contentSize.height > visibleRect.maxY + threshold
-                        // The threshold accounts for contentBottomPadding (inputAccessoryHeight + 64 ≈ 150)
-                        // Using a generous threshold ensures chevron hides when scrolled near bottom
-                        let threshold: CGFloat = 180  // contentBottomPadding (~150) + small buffer
-                        let contentBelow = geometry.contentSize.height > geometry.visibleRect.maxY + threshold
-                        // print("[ScrollGeo] contentH=\(Int(geometry.contentSize.height)) visibleMaxY=\(Int(geometry.visibleRect.maxY)) below=\(contentBelow)")
-                        return contentBelow
+                    .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                        geometry.contentSize.height - geometry.visibleRect.maxY
                     } action: { oldValue, newValue in
-                        // Always update hasContentBelow, even if value is same (for initial load)
-                        hasContentBelow = newValue
+                        let oldHasBelow = oldValue > bottomVisibilityPadding
+                        let newHasBelow = newValue > bottomVisibilityPadding
+
+                        if chatVM.isGenerating {
+                            if !userInteractedDuringGeneration && oldHasBelow != newHasBelow {
+                                userInteractedDuringGeneration = true
+                                showScrollToBottom = true
+                            }
+                            return
+                        }
+
+                        guard hasContentBelow != newHasBelow else { return }
+
+                        geometryBuffer.latest = newHasBelow
+                        guard !geometryBuffer.isScheduled else { return }
+                        geometryBuffer.isScheduled = true
+
+                        Task { @MainActor in
+                            await Task.yield()
+                            if let pending = geometryBuffer.latest, hasContentBelow != pending {
+                                if uiTraceEnabled {
+                                    logDebug("[ScrollGeo] hasBelow=\(pending)", category: .ui)
+                                }
+                                hasContentBelow = pending
+                            }
+                            geometryBuffer.isScheduled = false
+                        }
                     }
                 }
 
@@ -294,6 +357,16 @@ struct ChatView: View {
                 endPoint: .bottom
             )
         }
+    }
+
+    private final class StreamingBuffer {
+        var latest: String = ""
+        var isScheduled = false
+    }
+    
+    private final class GeometryBuffer {
+        var latest: Bool?
+        var isScheduled = false
     }
 
     private var bottomScrim: some View {
@@ -346,18 +419,161 @@ struct ChatView: View {
         case follow
     }
 
+    private func markScrollActivity() {
+        guard chatVM.isGenerating else { return }
+        guard !uiPauseLockedByUser else { return }
+
+        if !chatVM.uiUpdatesPaused {
+            chatVM.setUIUpdatesPaused(true)
+            if uiTraceEnabled {
+                logDebug("[UI Pause] begin", category: .ui)
+            }
+        }
+
+        scrollIdleTask?.cancel()
+        scrollIdleTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(scrollIdleDelayMs))
+            chatVM.setUIUpdatesPaused(false)
+            if uiTraceEnabled {
+                logDebug("[UI Pause] end", category: .ui)
+            }
+        }
+    }
+
+    private func pauseAutoFollowDueToUserScroll() {
+        autoFollowSuspendedByUser = true
+        showScrollToBottom = true
+        if scrollMode == .follow {
+            setScrollMode(.manual)
+        }
+
+        if chatVM.isGenerating {
+            userInteractedDuringGeneration = true
+            lockUIUpdatesForUserScroll()
+        }
+    }
+
+    private func lockUIUpdatesForUserScroll() {
+        guard chatVM.isGenerating else { return }
+        guard !uiPauseLockedByUser else { return }
+        uiPauseLockedByUser = true
+        chatVM.setUIUpdatesPaused(true)
+        if uiTraceEnabled {
+            logDebug("[UI Pause] locked by user scroll", category: .ui)
+        }
+    }
+
+    private func unlockUIUpdatesFromUser() {
+        guard uiPauseLockedByUser else { return }
+        uiPauseLockedByUser = false
+        chatVM.setUIUpdatesPaused(false)
+        if uiTraceEnabled {
+            logDebug("[UI Pause] unlocked", category: .ui)
+        }
+    }
+
+    private func beginProgrammaticScroll() {
+        isProgrammaticScroll = true
+        programmaticScrollTask?.cancel()
+        programmaticScrollTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(200))
+            isProgrammaticScroll = false
+        }
+    }
+
     private func updateChevronVisibility() {
+        let hasContent = visibleMessages.count >= 1 || chatVM.isGenerating
+
+        if autoFollowSuspendedByUser {
+            if showScrollToBottom != hasContent {
+                showScrollToBottom = hasContent
+            }
+            return
+        }
+
+        if scrollMode == .follow {
+            if showScrollToBottom {
+                showScrollToBottom = false
+            }
+            return
+        }
+
+        if chatVM.isGenerating && userInteractedDuringGeneration {
+            showScrollToBottom = true
+            return
+        }
+
         // Show chevron ONLY when content actually extends below visible area
         // We no longer show it just because we're in manual mode during generation
         // The geometry-based hasContentBelow is the source of truth
-        let hasContent = visibleMessages.count >= 1 || chatVM.isGenerating
         let shouldShow = hasContentBelow && hasContent
 
         // Debug logging (can be removed in production)
         // print("[ChevronV5] hasContentBelow=\(hasContentBelow) msgs=\(visibleMessages.count) generating=\(chatVM.isGenerating) shouldShow=\(shouldShow)")
 
         if showScrollToBottom != shouldShow {
+            if uiTraceEnabled {
+                logDebug("[Chevron] show=\(shouldShow) hasBelow=\(hasContentBelow) generating=\(chatVM.isGenerating)", category: .ui)
+            }
             showScrollToBottom = shouldShow
+        }
+    }
+
+    private func bufferStreamingChange(_ content: String) {
+        streamingBuffer.latest = content
+
+        guard !streamingBuffer.isScheduled else { return }
+        streamingBuffer.isScheduled = true
+
+        Task { @MainActor in
+            await Task.yield()
+            streamingBuffer.isScheduled = false
+            processStreamingChange(streamingBuffer.latest)
+        }
+    }
+
+    private func processStreamingChange(_ content: String) {
+        // During streaming:
+        // 1. When first tokens arrive (>20 chars) and user was at bottom - scroll to position question at top
+        // 2. Then let content fill downward (no more auto-scroll)
+        // 3. Update chevron visibility as content grows
+        if chatVM.isGenerating && !content.isEmpty {
+            // First tokens arrived - scroll so user's question is at the TOP of viewport
+            // Wait for at least ~20 chars so there's visible content before scrolling
+            if wasAtBottomBeforeSend && !hasScrolledToQuestion && !userInteractedDuringGeneration && content.count > 20 {
+                hasScrolledToQuestion = true
+                // Find the last user message ID to scroll to
+                if let lastUserMessage = visibleMessages.last(where: { $0.role == .user }) {
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .milliseconds(50))
+                        if !userInteractedDuringGeneration {
+                            withAnimation(.easeOut(duration: 0.3)) {
+                                // Scroll user's question to TOP of viewport (anchor: .top)
+                                // This positions the question at the very top with answer filling below
+                                beginProgrammaticScroll()
+                                scrollProxy?.scrollTo(lastUserMessage.id, anchor: .top)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // As content grows, check if it extends below visible area
+            // During streaming, we assume content below if we've scrolled to question
+            // and have substantial content (likely extends below fold)
+            if hasScrolledToQuestion && content.count > 200 {
+                // Content is likely below visible area, show chevron
+                if !showScrollToBottom {
+                    showScrollToBottom = true
+                }
+            }
+
+            // Also always update chevron based on geometry
+            updateChevronVisibility()
+        }
+
+        if scrollMode == .follow {
+            scheduleAutoScroll()
         }
     }
 
@@ -398,9 +614,11 @@ struct ChatView: View {
 
         if animated {
             withAnimation(.easeInOut(duration: 0.35)) {
+                beginProgrammaticScroll()
                 scrollProxy?.scrollTo(targetId, anchor: .bottom)
             }
         } else {
+            beginProgrammaticScroll()
             scrollProxy?.scrollTo(targetId, anchor: .bottom)
         }
     }

--- a/ANEMLLChat/ANEMLLChat/Views/Chat/MarkdownView.swift
+++ b/ANEMLLChat/ANEMLLChat/Views/Chat/MarkdownView.swift
@@ -11,11 +11,20 @@ struct MarkdownView: View {
     let content: String
     let isUserMessage: Bool
 
+    @State private var cachedContent: String = ""
+    @State private var cachedBlocks: [MarkdownBlock] = []
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            ForEach(Array(parseBlocks().enumerated()), id: \.offset) { _, block in
+            ForEach(Array(cachedBlocks.enumerated()), id: \.offset) { _, block in
                 renderBlock(block)
             }
+        }
+        .onAppear {
+            refreshCacheIfNeeded()
+        }
+        .onChange(of: content) { _, _ in
+            refreshCacheIfNeeded()
         }
     }
 
@@ -32,7 +41,7 @@ struct MarkdownView: View {
 
     // MARK: - Parsing
 
-    private func parseBlocks() -> [MarkdownBlock] {
+    private func parseBlocks(from content: String) -> [MarkdownBlock] {
         var blocks: [MarkdownBlock] = []
         let lines = content.components(separatedBy: "\n")
         var i = 0
@@ -139,6 +148,12 @@ struct MarkdownView: View {
         }
 
         return blocks
+    }
+
+    private func refreshCacheIfNeeded() {
+        guard content != cachedContent else { return }
+        cachedContent = content
+        cachedBlocks = parseBlocks(from: content)
     }
 
     private func parseTable(_ lines: [String]) -> MarkdownBlock? {
@@ -279,14 +294,44 @@ struct MarkdownView: View {
 
     @ViewBuilder
     private func renderInlineMarkdown(_ text: String) -> some View {
-        if let attributed = try? AttributedString(markdown: text, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)) {
-            Text(attributed)
-                .textSelection(.enabled)
-                .lineSpacing(3)
+        InlineMarkdownText(text: text)
+    }
+}
+
+private struct InlineMarkdownText: View {
+    let text: String
+
+    @State private var cachedText: String = ""
+    @State private var cachedAttributed: AttributedString?
+
+    var body: some View {
+        Group {
+            if let attributed = cachedAttributed {
+                Text(attributed)
+            } else {
+                Text(text)
+            }
+        }
+        .textSelection(.enabled)
+        .lineSpacing(3)
+        .onAppear {
+            refreshCacheIfNeeded()
+        }
+        .onChange(of: text) { _, _ in
+            refreshCacheIfNeeded()
+        }
+    }
+
+    private func refreshCacheIfNeeded() {
+        guard text != cachedText else { return }
+        cachedText = text
+        if let attributed = try? AttributedString(
+            markdown: text,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        ) {
+            cachedAttributed = attributed
         } else {
-            Text(text)
-                .textSelection(.enabled)
-                .lineSpacing(3)
+            cachedAttributed = nil
         }
     }
 }

--- a/ANEMLLChat/ANEMLLChat/Views/Chat/MessageBubble.swift
+++ b/ANEMLLChat/ANEMLLChat/Views/Chat/MessageBubble.swift
@@ -12,7 +12,7 @@ import AppKit
 import UIKit
 #endif
 
-struct MessageBubble: View {
+struct MessageBubble: View, Equatable {
     let message: ChatMessage
 
     @State private var isHovering = false
@@ -123,6 +123,10 @@ struct MessageBubble: View {
         #else
         return showCopyButton
         #endif
+    }
+
+    static func == (lhs: MessageBubble, rhs: MessageBubble) -> Bool {
+        lhs.message == rhs.message
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches streaming/rendering and inference threading by introducing detached tasks and buffered UI updates, which could change timing/cancellation behavior and introduce concurrency edge cases. No auth/data persistence logic is modified beyond display/UX behavior.
> 
> **Overview**
> **Improves streaming responsiveness and scroll stability during generation.** UI updates from streaming are now buffered/throttled, can be paused while the user scrolls (then flushed), and the view coordinates pre-scroll/typing-peek positioning to avoid scroll races and unwanted auto-follow.
> 
> **Moves heavy inference prep off the main actor and reduces callback churn.** `InferenceService.generateResponse` now prepares chat templates/context trimming in a detached task and batches token/history emissions (~30fps, min chunking), with updated cancellation detection via `stopReason` and a `nonisolated` static `resolveSystemPrompt`.
> 
> **Reduces render work during streaming.** `MarkdownView` caches parsed blocks/inline attributed strings, `MessageBubble` becomes `Equatable` for cheaper diffing, and conversation previews skip empty last messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39398b803168f0184f19e6ff541887ec3c47490d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->