### PR TITLE
Add repo-contained agent skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,17 +7,12 @@ A skill is a set of local instructions stored in a `SKILL.md` file.
 - `ane-divergence-analysis`
   - Compare PyTorch vs CoreML/ANE and HuggingFace Transformers vs CoreML for decoder-only LLMs in this repo.
   - Use for token/logit divergence, instability, ANE lowering issues, and parity metrics (KL, correlation, entropy, repetition).
-  - File: `/Users/anemll/.codex/skills/custom/ane-divergence-analysis/SKILL.md`
+  - File: `agents/skills/ane-divergence-analysis/SKILL.md`
 
 - `ane-lowering-plan`
   - Create an ANE-legal CoreML/MIL lowering plan for decoder-only Transformers from HF or JAX/Flax.
   - Use for conversion/debugging on ANE, KV-cache/state contract issues, sliding-window/global attention, and chunked FFN.
-  - File: `/Users/anemll/.codex/skills/custom/ane-lowering-plan/SKILL.md`
-
-- `anemll-macos-agent`
-  - Control macOS UI via AnemllAgentHost HTTP API for screenshots, clicks, typing, and window/screen automation.
-  - Use only when GUI interaction is required.
-  - File: `/Users/anemll/.codex/skills/custom/anemll-macos-agent/SKILL.md`
+  - File: `agents/skills/ane-lowering-plan/SKILL.md`
 
 ### Trigger rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,14 +6,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ANEMLL (pronounced "animal") is an open-source project for accelerating Large Language Models (LLMs) on Apple Neural Engine (ANE). The project converts Hugging Face models to CoreML format for on-device inference on Apple devices.
 
+## Repo Agent Resources
+
+Repo-contained agent workflows live under `agents/skills/` so Codex and Claude can use the same instructions without relying on machine-local paths.
+
+- `agents/skills/ane-divergence-analysis/SKILL.md`: PyTorch vs CoreML/ANE divergence, parity, and instability workflows
+- `agents/skills/ane-lowering-plan/SKILL.md`: ANE-safe lowering plans, shape/state contracts, and legality checks
+
+When a task clearly matches one of these workflows, read only the relevant skill file instead of loading unrelated guidance.
+
 ## Command Allowlist (Claude Code)
 
 Approved commands for Claude Code in this repo:
 ```bash
 osascript -e 'tell application "System Events" to key code 121'  # page down
 sleep 0.5
-export ANEMLL_HOST="http://127.0.0.1:8765"
-curl ...
 ```
 
 ## Development Commands

--- a/agents/skills/ane-divergence-analysis/SKILL.md
+++ b/agents/skills/ane-divergence-analysis/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: ane-divergence-analysis
+description: Compare PyTorch vs CoreML/ANE and HuggingFace Transformers vs CoreML for released decoder-only LLM workflows in this repo. Use when debugging token/logit divergence, instability, or ANE lowering issues; when running tests/dev/*_compare.py or tests/dev/*_divergence_harness.py; or when you need prompt/decode parity metrics (KL, correlation, entropy, repetition).
+---
+
+# ANE Divergence Analysis
+
+## Overview
+
+Use the divergence harnesses under `tests/dev/` to measure parity, instability, and repetition between
+PyTorch, HuggingFace Transformers, and CoreML/ANE exports. Keep runs deterministic (greedy decoding,
+`--no-think`) while diagnosing, then scale to batch harnesses for instability datasets.
+
+## Workflow Decision Tree
+
+1) Pick the comparison target:
+- **Generic HF vs CoreML via meta.yaml (Gemma-style exports)** -> `tests/dev/test_gemma3_compare.py`
+- **Chunked CoreML vs PyTorch** -> `tests/dev/test_gemma3_coreml_chunks_vs_pytorch.py`
+
+2) Choose scope:
+- **Single prompt** -> use `*_compare.py`
+- **Batch / instability dataset** -> `tests/dev/gemma3_divergence_harness.py`
+
+## Preflight Checklist
+
+- Use the same chat template and special-token settings on both sides.
+- Align `context_length` / `state_length` with CoreML `meta.yaml` (override only when intentional).
+- Use greedy decoding for parity; avoid sampling while debugging divergence.
+- Prefer `driver coreml` to mimic ANE behavior; use `driver pt` for parity baselines.
+- For diagnostic exports, run the wrapper once before `torch.jit.trace(...)` and print the traced output name and shape.
+- For suspect `.mlpackage` exports, compile them and inspect `model.mil` before blaming backend math.
+
+## Core Commands
+
+### Gemma/HF vs CoreML (generic meta.yaml)
+
+```bash
+python tests/dev/test_gemma3_compare.py <coreml_dir_or_meta.yaml> \
+  --hf-reference <hf_model_id> --prompt "..." --driver coreml --no-think
+```
+
+### Batch HF vs CoreML (Gemma-style)
+
+```bash
+python tests/dev/gemma3_divergence_harness.py <coreml_dir_or_meta.yaml> \
+  --hf-reference <hf_model_id> --dataset <prompts.jsonl> --out-dir runs/<name>
+```
+
+### Chunked CoreML vs PyTorch
+
+```bash
+python tests/dev/test_gemma3_coreml_chunks_vs_pytorch.py <coreml_dir_or_meta.yaml> \
+  --prompt "..." --no-think
+```
+
+## Export Probe Checks
+
+Use these when a diagnostic/CoreML probe appears to expose the wrong tensor, wrong shape, or unexpected downstream ops.
+
+### Trace-sample print before `torch.jit.trace(...)`
+
+Run the wrapper once on representative sample inputs and print:
+- output name
+- output shape
+
+This catches wrapper-return mistakes early, especially when you intend to export a pre-projection payload but the wrapper still returns post-projection hidden states.
+
+### Compile-check the exported package
+
+```bash
+xcrun coremlcompiler compile <model.mlpackage> <out_dir>
+```
+
+Then inspect:
+
+```bash
+find <out_dir> -name model.mil -print
+sed -n '1,240p' <out_dir>/<compiled>.mlmodelc/model.mil
+```
+
+Check `model.mil` for:
+- final output name and shape
+- unexpected `output_hidden_states` vs payload output names
+- unexpected `o_proj`/LM-head/final projection still present on the output path
+- rank regressions (for example, payload expected as 4D but exported as hidden-size 3D)
+
+## Interpret Metrics
+
+- Use **match_rate**, **KL**, and **correlation** to measure parity; lower correlation and higher KL indicate drift.
+- Watch instability signals: stuck token, phrase repeat, rep4 spike, entropy collapse, margin explosion.
+
+## Pseudocode: Divergence Calculations
+
+```text
+# Inputs per step:
+#   pt_logits[vocab], cm_logits[vocab]
+# Outputs per step:
+#   kl, corr, entropy_cm, match
+
+softmax(x):
+  x = x - max(x)
+  return exp(x) / sum(exp(x))
+
+entropy(p):
+  p = clip(p, eps, 1)
+  return -sum(p * log(p))
+
+kl_divergence(p, q):
+  p = clip(p, eps, 1)
+  q = clip(q, eps, 1)
+  return sum(p * log(p / q))
+
+corrcoef(a, b):
+  a_mean = mean(a); b_mean = mean(b)
+  a_std = std(a); b_std = std(b)
+  if a_std < eps or b_std < eps: return NaN
+  return mean((a - a_mean) * (b - b_mean)) / (a_std * b_std)
+
+pt_probs = softmax(pt_logits)
+cm_probs = softmax(cm_logits)
+
+kl = kl_divergence(pt_probs, cm_probs)   # KL(PT || CM)
+corr = corrcoef(pt_logits, cm_logits)
+entropy_cm = entropy(cm_probs)
+match = (argmax(pt_logits) == argmax(cm_logits)) ? 1 : 0
+
+# Aggregate over steps:
+kl_mean = mean(kl_list)
+corr_mean = mean(corr_list)
+entropy_mean = mean(entropy_cm_list)
+match_rate = mean(match_list)
+```
+
+## Divergence Triage
+
+1) **Prompt-phase mismatch**: Verify tokenizer, chat template, and special-token settings before blaming backend math.
+2) **Decode-only mismatch**: Flip `--driver` between `pt` and `coreml` to isolate ANE behavior; shorten `--max-tokens`.
+3) **Quantization vs conversion**: Compare HF vs CoreML first; if chunked PT vs CoreML is also close, suspect conversion-specific drift elsewhere in the pipeline.
+4) **Instability loops**: Use the batch harness and inspect per-prompt NPZ/JSON for rep4/entropy/margin spikes.
+5) **Diagnostic export mismatch**: If a probe package looks wrong in Xcode or Netron, compile it and inspect `model.mil`; verify the traced wrapper return tensor before changing model math.
+
+## Required References
+
+- Read `tests/dev/DIVERGENCE_HARNESS.md` for released harness usage and dataset guidance.
+- Inspect `tests/dev/test_gemma3_compare.py` and `tests/dev/gemma3_divergence_harness.py` for generic HF vs CoreML comparisons.
+- Inspect `tests/dev/test_gemma3_coreml_chunks_vs_pytorch.py` for chunked CoreML vs PyTorch comparisons.

--- a/agents/skills/ane-lowering-plan/SKILL.md
+++ b/agents/skills/ane-lowering-plan/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: ane-lowering-plan
+description: Create an ANE-legal CoreML/MIL lowering plan for decoder-only Transformers from Hugging Face or JAX/Flax, including architecture fingerprinting, KV-cache/state contracts, and legality constraints. Use when converting or debugging HF/JAX models for ANE (Core ML) deployment, especially when sliding window/global attention, chunked FFN, or monolithic multi-function models are involved. Also use to analyze PyTorch vs CoreML divergence using tests/dev compare harnesses. Do not use for encoder-decoder models or non-Transformer architectures.
+---
+
+# ANE Lowering Plan (HF/JAX -> CoreML/MIL)
+
+## What this skill is for
+Produce a repeatable, testable lowering plan that turns a decoder-only Transformer into ANE-compatible CoreML/MIL with a precise shape/state contract and legality checklist.
+
+## When to use / when not to use
+Use when:
+- Converting HF Transformers or JAX/Flax decoder-only models to CoreML/MIL for ANE.
+- Debugging chunked vs monolithic exports, sliding-window vs global attention, or KV-cache/state correctness.
+- You need a strict, testable plan: shapes, state I/O, and legality rules.
+
+Do not use when:
+- Model is encoder-decoder, RNN/SSM, or non-decoder-only Transformer.
+- Target is GPU-only or non-CoreML backends without ANE constraints.
+
+## Required inputs
+- Model config (HF `config.json` or JAX/Flax equivalent): layers, heads, hidden size, kv heads, rope, norm type.
+- Weights (HF safetensors or JAX checkpoint) and tokenizer assets.
+- Target context length + prefill batch size.
+- Quantization plan (LUT bits, per-channel group size) if used.
+- Attention pattern definition (full/global vs sliding/local) and window size.
+
+## Step-by-step procedure
+1) **Fingerprint the architecture**
+   - Extract hidden size, num layers, num heads, num kv heads (GQA/MQA), intermediate size, norm type, RoPE base, vocab size.
+   - Detect attention pattern: full/global vs sliding/local (and its interval or layer list).
+
+2) **Lock fixed shapes**
+   - Choose `context_length`, `state_length`, and `prefill_batch_size`.
+   - Ensure all tensors are static and last-dim >= 64.
+
+3) **Qualify FP16 compatibility (Gemma3 priority)**
+   - Run FP16 compatibility check before ANE conversion.
+   - If residual overflow risk exists, apply weight scaling (preferred) or safety clamp.
+   - See `docs/GEMMA3_FP16_SCALING.md` and `anemll/utils/fp16_compatibility_check.py`.
+
+4) **Define KV-cache/state contract**
+   - Decide unified vs split cache (local/global) and the exact state layout.
+   - Document prefill vs decode state update rules.
+
+5) **Define attention masks**
+   - Use one causal mask tensor; slice it consistently for prefill and decode.
+   - For sliding window: ensure local attention window masking matches KV cache window.
+
+6) **Lower to ANE-safe ops**
+   - Use Conv2D/1x1 for linear projections.
+   - Avoid dynamic reshape/transpose order that yields last-dim < 64.
+
+7) **Chunking plan (if applicable)**
+   - Split layers across chunks with remainder-aware indexing.
+   - Validate each chunk's layer range and number of layers.
+
+8) **Build function set**
+   - Standard: `infer` and `prefill`.
+   - For sliding-window rotation: include `infer_rotate` and `prefill_rotate`.
+
+9) **Combine + metadata**
+   - Combine into multi-function model if needed.
+   - Generate `meta.yaml` with functions list, context/state length, LUT bits.
+
+10) **Verify**
+   - Run smoke tests and numeric sanity checks.
+   - For probe/debug exports, print the traced wrapper output name and shape before `torch.jit.trace(...)`.
+   - Compile suspect `.mlpackage` artifacts and inspect `model.mil` to confirm the real exported output path.
+
+## Architecture fingerprint checklist
+- Layers: `num_hidden_layers`
+- Hidden size: `hidden_size`
+- Attention heads: `num_attention_heads`
+- KV heads: `num_key_value_heads` (GQA/MQA)
+- Intermediate: `intermediate_size`
+- Norm type: RMSNorm/LayerNorm
+- RoPE: `rope_theta` and any local/global base
+- Attention pattern: sliding/local window size + global layer indices
+
+## Shape/state contract (prefill vs decode)
+
+### Chunked or monolithic (unified cache)
+| Phase | Inputs | Shapes (canonical) | Outputs/State |
+|---|---|---|---|
+| Prefill | `input_ids`, `position_ids`, `causal_mask`, `current_pos` | `input_ids:[1,B]` `position_ids:[B]` `causal_mask:[1,1,B,context]` `current_pos:[1]` | Updates state KV cache for positions `[current_pos, current_pos+B)` |
+| Decode | `input_ids`, `position_ids`, `causal_mask`, `current_pos` | `input_ids:[1,1]` `position_ids:[1]` `causal_mask:[1,1,1,context]` `current_pos:[1]` | Updates state at `current_pos` and produces next logits |
+
+**KV cache** (unified): `kv_cache:[2*num_layers, num_kv_heads, state_length, head_dim]`
+
+### Split cache (sliding/local + global)
+- Local cache: `kv_cache_local:[2*num_local_layers, num_kv_heads, sliding_window, head_dim]`
+- Global cache: `kv_cache_global:[2*num_global_layers, num_kv_heads, state_length, head_dim]`
+- Decode uses local window for local layers and full state_length for global layers.
+
+### Rotation vs fill (sliding window)
+- Apply only if the model supports sliding window attention; otherwise use standard full-context causal masking.
+- **Fill mode** (`pos < sliding_window`): write sequentially.
+- **Rotate mode** (`pos >= sliding_window`): rotate/shift window, update at end.
+- Ensure causal mask matches the windowed key length used by each layer.
+
+## ANE/MIL lowering rules (do / don't)
+**Do**
+- Use Conv2D (1x1) for linear projections (QKV, MLP, LM head).
+- Keep last-dim >= 64 (pad/reshape if needed).
+- Use static shapes and constant sizes in MIL graph.
+- Slice causal masks instead of recomputing per op.
+- For RMSNorm on ANE, use the ANEMLL RMS hack: `concat([x, -x]) -> layer_norm (no affine) -> slice back -> scale` (see `QwenRMSNorm`/`QwenHeadNorm` in `qwen_model`).
+
+**Don't**
+- Don't emit dynamic control flow in MIL.
+- Don't rely on dynamic reshape that yields last-dim < 64.
+- Don't use ops unsupported by ANE (dynamic gather/scatter with unknown shapes).
+
+## Illegal-op avoidance checklist
+- [ ] No dynamic shapes or control flow in exported graph
+- [ ] No `Gather`/`Slice` with data-dependent indices in MIL
+- [ ] Avoid casts that create unsupported types mid-graph
+- [ ] Ensure `causal_mask` is static shape with correct dtype
+- [ ] No last-dim < 64 in any Conv2D/MatMul path
+
+## Common errors and fixes
+| Error signature | Likely cause | Fix |
+|---|---|---|
+| `GemmaTokenizer requires the SentencePiece library` | Missing dependency | Install `sentencepiece` in env |
+| `Provided key "update_mask" ... does not match any model input` | Model removed `update_mask` input | Only pass if present in model inputs |
+| `tuple index out of range` when reshaping weights | Wrong tensor rank assumption | Check weight shapes before `view`; handle missing dims |
+| Missing chunk files / identical layer norms | Chunking drops remainder layers | Use remainder-aware chunk split (last chunk gets extra) |
+| `integer expression expected` in convert_monolith | Non-numeric step labels | Normalize step labels for comparison |
+| `Infer model not found` during combine | Rotate functions not generated | Run rotate conversions for context > sliding_window |
+| Palettize warning channel_group_size | channel count not divisible by group | Accept skip or adjust group size |
+
+## Minimal verification protocol
+1) **Smoke test**: run `tests/chat.py` and `tests/chat_full.py` with same prompt and max tokens; check responses are coherent.
+2) **Numerical sanity**: check logits range (roughly -20 to +20) and no hidden-state explosions across chunks.
+3) **Mask sanity**: confirm causal mask shapes match model inputs and window size.
+4) **State sanity**: verify KV-cache shapes match contract and update positions are consistent.
+
+## FP16 qualification (Gemma3 / ANE)
+- **Required** for Gemma3: BF16-trained residuals can overflow FP16 on ANE.
+- Use `anemll/utils/fp16_compatibility_check.py --model <id> --sweep` to detect overflow risk.
+- Prefer **weight scaling** over runtime clamp; clamp only as a safety net.
+- If scaling is needed, compute alpha from observed peak (`target_max ~= 50,000`) and apply via conversion flag (for example, `--fp16-scale`).
+- Reference: `docs/GEMMA3_FP16_SCALING.md` and the generated FP16 preflight report for recommended next steps.
+
+## ANE divergence analysis (PyTorch vs CoreML)
+Use when outputs drift between CoreML/ANE and PyTorch or HF reference. Prefer deterministic runs (greedy, no-think).
+
+### Workflow decision tree
+1) **Pick comparison target**
+   - Gemma-style via meta.yaml: `tests/dev/test_gemma3_compare.py`
+   - Chunked CoreML vs PyTorch: `tests/dev/test_gemma3_coreml_chunks_vs_pytorch.py`
+
+2) **Pick scope**
+   - Single prompt: `*_compare.py`
+   - Batch dataset: `tests/dev/gemma3_divergence_harness.py`
+
+### Preflight checklist
+- Match chat templates and special-token settings on both sides.
+- Align `context_length` / `state_length` with `meta.yaml`.
+- Use greedy decoding for parity (avoid sampling).
+- Use `driver coreml` to mimic ANE; `driver pt` for baseline.
+
+### Core commands (examples)
+```bash
+python tests/dev/test_gemma3_compare.py <coreml_dir_or_meta.yaml> \
+  --hf-reference <hf_model_id> --prompt "..." --driver coreml --no-think
+
+python tests/dev/test_gemma3_coreml_chunks_vs_pytorch.py <coreml_dir_or_meta.yaml> \
+  --prompt "..." --no-think
+```
+
+### Interpret metrics
+- Track **match_rate**, **KL**, **correlation**, **entropy**, **rep4**.
+- Drift signals: correlation down, KL up, entropy collapse, rep4 spikes.
+
+### Divergence triage
+1) **Prompt-phase mismatch** -> verify tokenizer, template, and special-token handling first.
+2) **Decode-only mismatch** -> shorten `--max-tokens`, compare `driver pt` vs `driver coreml`.
+3) **Quantization vs conversion** -> HF reference vs CoreML to isolate quantization effects.
+4) **Instability loops** -> inspect per-prompt outputs; check repetition/entropy/margin spikes.
+5) **Probe package looks wrong** -> compile the `.mlpackage` and inspect `model.mil`; verify the traced wrapper return tensor before changing the lowering plan.
+
+### Probe export sanity checks
+- Before tracing a diagnostic wrapper, run one sample forward pass and print the output name and shape.
+- Compile debug/probe packages with:
+
+```bash
+xcrun coremlcompiler compile <model.mlpackage> <out_dir>
+```
+
+- Inspect `model.mil` for:
+  - final output name and shape
+  - unexpected projections still on the output path (`o_proj`, LM head, final logits)
+  - unexpected rank collapse or hidden-state-shaped outputs when a payload probe should stay 4D
+
+### Required references
+- `tests/dev/DIVERGENCE_HARNESS.md`
+- `tests/dev/test_gemma3_compare.py`
+- `tests/dev/gemma3_divergence_harness.py`
+- `tests/dev/test_gemma3_coreml_chunks_vs_pytorch.py`
+- `docs/GEMMA3_FP16_SCALING.md`
+- `anemll/utils/fp16_compatibility_check.py`
+
+## Example (Gemma3 sliding window)
+- Model: Gemma3 1B, context 4096, sliding_window 512, global layers every 6.
+- Functions: `infer`, `prefill`, `infer_rotate`, `prefill_rotate`.
+- Split cache: local window cache for sliding layers + global cache for full-attention layers.
+- Validation: prefill for first 512 with fill mode; rotate after 512; compare outputs across chunked vs monolithic.
+
+## Version assumptions (freshness guards)
+- coremltools 9.x (ML Program path) and coremlcompiler 35xx.
+- macOS 15+ for ANE compilation.
+- Python 3.9+ runtime.
+
+## Likely-to-change warnings
+- coremltools pass names and legality constraints can change between releases.
+- Tokenizer special token IDs (EOS/EOT) may differ by model family.
+- ANE backend constraints may tighten or expand with OS updates.

--- a/tests/dev/DIVERGENCE_HARNESS.md
+++ b/tests/dev/DIVERGENCE_HARNESS.md
@@ -1,0 +1,101 @@
+# ANEMLL Divergence Harness
+
+Tools for detecting and analyzing divergence or instability between PyTorch/HuggingFace reference runs and CoreML/ANE exports in the released `main` workflow.
+
+## Supported entry points
+
+| File | Purpose |
+|---|---|
+| `test_gemma3_compare.py` | Interactive HF vs CoreML comparison with token/logit metrics |
+| `gemma3_divergence_harness.py` | Batch dataset evaluation for instability analysis |
+| `test_gemma3_coreml_chunks_vs_pytorch.py` | Chunked CoreML vs PyTorch comparison |
+
+## What to measure
+
+- **Token divergence**: next-token disagreement between reference and CoreML
+- **Logit drift**: KL increase, correlation drop, margin changes
+- **Entropy collapse**: CoreML becomes overconfident too early
+- **Repetition loops**: rep4/phrase repetition spikes over decode
+- **State drift**: chunked or cached decode diverges over longer sequences
+
+## Quick start
+
+### Single prompt: HF vs CoreML
+
+```bash
+python tests/dev/test_gemma3_compare.py <coreml_dir_or_meta.yaml> \
+  --hf-reference <hf_model_id> \
+  --prompt "What is the capital of France?" \
+  --driver coreml \
+  --no-think
+```
+
+### Batch dataset: instability scan
+
+```bash
+python tests/dev/gemma3_divergence_harness.py <coreml_dir_or_meta.yaml> \
+  --hf-reference <hf_model_id> \
+  --dataset <prompts.jsonl> \
+  --out-dir runs/<name>
+```
+
+### Chunked CoreML vs PyTorch
+
+```bash
+python tests/dev/test_gemma3_coreml_chunks_vs_pytorch.py <coreml_dir_or_meta.yaml> \
+  --prompt "Explain rotary embeddings." \
+  --no-think
+```
+
+## Preflight
+
+- Match tokenizer/chat-template behavior on both sides.
+- Match `context_length` and `state_length` with `meta.yaml`.
+- Use greedy decoding while debugging divergence.
+- Prefer short prompts first, then longer prompts once parity is understood.
+- If a debug export looks suspicious, compile the `.mlpackage` and inspect `model.mil`.
+
+## Suggested prompt dataset fields
+
+JSONL is recommended:
+
+```json
+{
+  "id": "prompt_001",
+  "prompt": "What is the capital of France?",
+  "category": "factual",
+  "risk": "low",
+  "target_len": "short"
+}
+```
+
+Useful `risk` buckets:
+- `low`
+- `repetition`
+- `reasoning`
+- `long_context`
+
+## Instability signals
+
+| Signal | Meaning |
+|---|---|
+| `match_rate` down | Token-level drift is accumulating |
+| `KL` up | Distribution mismatch is widening |
+| `correlation` down | Logit shape diverges even if argmax still matches |
+| `entropy` collapse | Model becomes overconfident or stuck |
+| `rep4` spike | Repetition loop likely |
+
+## Practical triage
+
+1. Verify prompt formatting and tokenizer behavior.
+2. Compare HF vs CoreML on a short prompt.
+3. If close, compare chunked CoreML vs PyTorch to isolate state/chunk drift.
+4. Run the batch harness on a prompt set to identify unstable categories.
+5. If a probe export looks wrong, inspect compiled `model.mil` before changing model math.
+
+## Outputs worth keeping
+
+- Per-prompt JSON summaries
+- NPZ arrays for per-step metrics
+- A CSV or summary table sorted by worst `match_rate`, highest `KL`, and lowest `correlation`
+- The exact `meta.yaml` and command line used for the run


### PR DESCRIPTION
## Summary
- move Codex skill references to repo-contained files under `agents/skills/`
- add repo-local divergence and lowering skill docs for released workflows on `main`
- add a public `tests/dev/DIVERGENCE_HARNESS.md` guide and update Claude guidance to reference repo-local agent resources

## Notes
- excludes macOS UI automation guidance from this repo
- excludes unreleased AQ1-specific workflow references

## Testing
- not run (documentation and agent workflow scaffolding only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/agent workflow scaffolding only, with no code-path, model conversion, or runtime behavior modifications.
> 
> **Overview**
> Moves agent skill references from machine-local paths to **repo-contained** `agents/skills/` docs so different agents can share the same workflows.
> 
> Adds two new skill playbooks—`ane-divergence-analysis` and `ane-lowering-plan`—and introduces `tests/dev/DIVERGENCE_HARNESS.md` as a public guide for running the released divergence/instability harnesses. Updates `AGENTS.md` and `CLAUDE.md` to point at these repo-local resources and drops the macOS UI automation skill reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e07b76bb8d41a110ccfc82344ef28504eb9b147. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->